### PR TITLE
Make lube volatile

### DIFF
--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -69,6 +69,7 @@
   name: reagent-name-space-lube
   desc: reagent-desc-space-lube
   slippery: true
+  evaporates: true
   physicalDesc: reagent-physical-desc-shiny
   flavor: funny
   color: "#77b58e"


### PR DESCRIPTION
Requires https://github.com/space-wizards/space-station-14/pull/33399
Tests will most likely fail until then, that is normal.

## About the PR
Makes space lube evaporate.

## Why / Balance
Rules become mechanics.
While very funny, space lube is borderline griefy and very annoying to play against in a lot of situations. Space lube foam was being used by non-antagonists for fun, or used on the shuttle to make it miserable.
This will nerf some syndicate strategies, but they will still live on, just under a shorter timespan.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Jajsha
- tweak: Lube now evaporates.
