### PR TITLE
Give Service Worker Hydroponics access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -11,7 +11,6 @@
   - Maintenance
   - Bar
   - Kitchen
-  extendedAccess:
   - Hydroponics
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -11,7 +11,9 @@
   - Maintenance
   - Bar
   - Kitchen
-  - Hydroponics
+  - Hydroponics # Harmony-specific access tweak
+  # extendedAccess:
+  # - Hydroponics
 
 - type: startingGear
   id: ServiceWorkerGear


### PR DESCRIPTION
_Please be patient, this is my first ever PR._
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gives service worker Hydroponics Access.

## Why / Balance
The service worker should be able to assist in all aspects of food service, not strictly the bar and kitchen. Botany is one of the lesser-populated service roles despite it's essential role to chemistry and kitchen and this PR allows service worker players to fill in for staff without disrupting chemistry or kitchen. 

## Technical details
Added Hydroponics access to service_worker.yml and removed Hydroponics as extended access.

## Media
![Screenshot 2025-01-12 175258](https://github.com/user-attachments/assets/f2c978b1-5d1a-44f5-97ab-203d74d514e8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Anno_Midi
- tweak: Gave service worker hydroponics access

