### PR TITLE
Add items to the aghost bag

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -126,6 +126,7 @@
       insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
       ejectOnBreak: true
       swap: false
+      startingItem: UniversalIDCard # Harmony
       whitelist:
         components:
         - IdCard

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -144,7 +144,7 @@
     - trayScanner
     - AccessConfiguratorUniversal
     - Multitool
-    # Harmony items below this point
+    # Begin harmony specific admin tools
     - Omnitool
     - WelderExperimental
     - HolofanProjector
@@ -155,6 +155,7 @@
     - BluespaceBeaker
     - SyringeBluespace
     - RubberStampCentcom
+    # End harmony specific admin tools
 
 #Gladiator with spear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -148,6 +148,7 @@
     - Omnitool
     - WelderExperimental
     - HolofanProjector
+    - AppraisalTool
     - AnomalyScanner
     - WeaponPistolCHIMP
     - EmagUnlimited

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -144,6 +144,16 @@
     - trayScanner
     - AccessConfiguratorUniversal
     - Multitool
+    # Harmony items below this point
+    - Omnitool
+    - WelderExperimental
+    - HolofanProjector
+    - AnomalyScanner
+    - WeaponPistolCHIMP
+    - EmagUnlimited
+    - BluespaceBeaker
+    - SyringeBluespace
+    - RubberStampCentcom
 
 #Gladiator with spear
 - type: startingGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added various items to the aghost bag, all of which were specifically requested by admins.
Made the access configurator admins spawn with have an ID card inside by default

## Why/Balance
Allows admins to be able to handle some things more effectively
- Omnitool, holofan and welder added to allow admins to fix things without spawning themselves tools every time
- Anomaly scanner and CHIMP added for better handling of anomalies inside players
- Bluespace beaker and syringe for better reagent handling
- Emag and cenctomm stamp for fax machine stuff (You need to emag the fax machine to send things to the nukie planet)

## Technical details
Just YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
Not player facing