### PR TITLE
allow pen printing at autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -205,6 +205,7 @@
       - Flare
       - CassetteTape # DeltaV
       - TapeRecorder # DeltaV
+      - Pen # Harmony Change: Allow pen printing
 
   - type: EmagLatheRecipes
     emagStaticRecipes:

--- a/Resources/Prototypes/_Harmony/Recipes/Lathes/paper.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Lathes/paper.yml
@@ -4,3 +4,10 @@
   completetime: 2
   materials:
     Wood: 50
+
+- type: latheRecipe
+  id: Pen
+  result: Pen
+  completetime: 1
+  materials:
+    Steel: 25 # should probably cost less than matter bins or whatever


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
makes pens printable in autolathe

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
why are they not

![image](https://github.com/user-attachments/assets/ff1c4bea-8835-4450-baf2-32c1835d2de2)

## Technical details
<!-- Summary of code changes for easier review. -->
upstream yml change: add pen to autolathe static recipes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
tested ingame, works

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now print pens at an autolathe.
