### PR TITLE
Adds sunglasses to QM locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -18,6 +18,7 @@
     - id: RubberStampDenied
     - id: RubberStampQm
     - id: AstroNavCartridge
+    - id: ClothingEyesGlassesSunglasses # Harmony
 
 - type: entity
   id: LockerQuarterMasterFilled
@@ -134,6 +135,7 @@
     - id: RubberStampHop
     - id: WeaponDisabler
     - id: ClothingEyesHudCommand
+    - id: ClothingEyesGlassesSunglasses # Harmony
 
 - type: entity
   id: LockerHeadOfPersonnelFilled
@@ -221,6 +223,7 @@
     - id: MedkitFilled
     - id: RubberStampCMO
     - id: MedTekCartridge
+    - id: ClothingEyesGlassesSunglasses # Harmony
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -272,6 +275,7 @@
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
+    - id: ClothingEyesGlassesSunglasses # Harmony
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -135,7 +135,6 @@
     - id: RubberStampHop
     - id: WeaponDisabler
     - id: ClothingEyesHudCommand
-    - id: ClothingEyesGlassesSunglasses # Harmony
 
 - type: entity
   id: LockerHeadOfPersonnelFilled
@@ -223,7 +222,6 @@
     - id: MedkitFilled
     - id: RubberStampCMO
     - id: MedTekCartridge
-    - id: ClothingEyesGlassesSunglasses # Harmony
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -275,7 +273,6 @@
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
-    - id: ClothingEyesGlassesSunglasses # Harmony
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
## About the PR
Does what it says on the tin: Adds sunglasses to the QM locker 

## Why / Balance
The primary defense for department heads outside of captain/HoS is using flashes. Which also blind the user in most use cases. It feels weird that heads are supplied with this defense but not with the eye protection to use it effectively. 

Additionally, while sunglasses are definitely not super _hard_ to find, this prevents heads from having to run into the halls during a code red to find a vendor, and from having to source sunglasses early, which feels like it takes away from the element of not treating every shift like it is going to kill you from round start.

As of 02/01/2025: This has been reduced to just the QM

## Technical details
Adds sunglasses to filled QM locker in resources/prototypes/catalog/fills/lockers/heads

## Media
![image](https://github.com/user-attachments/assets/9bdf5795-60ab-404e-84e9-db2ef2077930)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
02/01/2025: Reduced to _just_ QM locker per discussion

**Changelog**
- add: adds sunglasses to filled QM locker

