### PR TITLE
Removed Loop from Default Pool

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -9,8 +9,7 @@
   - Elkridge
   - Fland
   #- Gate
-  # - Loop
-  # Harmony, commented out due to technical issues  
+  #- Loop # Harmony, commented out due to technical issues 
   - Marathon
   - Meta
   - Oasis

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -9,7 +9,8 @@
   - Elkridge
   - Fland
   #- Gate
-  - Loop
+  # - Loop
+  # Harmony, commented out due to technical issues  
   - Marathon
   - Meta
   - Oasis


### PR DESCRIPTION
## About the PR
Removed Loop from the default map pool

## Why / Balance
Loop was merged as a largely untested map, and while it shows promise, it is deeply broken to the point of requiring admin intervention to function properly. It also breaks mapping standards. The following is a list of _examples_ of Loop's issues, but should not be treated as all-inclusive:

- Atmos breaks mapping standards, with pipes passing under walls in several places (see attached image for an example)
- Engineering is not properly set up, and includes a generator that results in an entirely infallible Tesla setup
- Salvage airlock is missing a hullplate, meaning that Cargo gets spaced through routine use
- Disposals lacks any kind of spacing capacity, meaning that it can and does become a miasma hellscape (a disposals bin was added with a chute into space. Entirely insufficient.)

I should add here that much of Loop's design is _fine_. I don't hate the map. But it is not currently playable.

## Technical details
Commented Loop out of the default map pool

## Media
Woe, pipes under walls be upon ye
![image](https://github.com/user-attachments/assets/940866ef-0f30-49cf-974a-6ca520c37b56)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
- remove: Loop (from default pool)

