### PR TITLE
Remove the raffle from slimes, spiders, and carps.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2389,8 +2389,10 @@
     name: ghost-role-information-giant-spider-name
     description: ghost-role-information-giant-spider-description
     rules: ghost-role-information-giant-spider-rules
-    raffle:
-      settings: short
+    # harmony start: remove ghost role raffle from spiders
+    # raffle:
+    #   settings: short
+    # harmony end
   - type: GhostTakeoverAvailable
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -170,8 +170,10 @@
       name: ghost-role-information-sentient-carp-name
       description: ghost-role-information-sentient-carp-description
       rules: ghost-role-information-space-dragon-summoned-carp-rules
-      raffle:
-        settings: short
+      # harmony start: remove ghost role raffle from carps
+      # raffle:
+      #   settings: short
+      # harmony end
     - type: GhostTakeoverAvailable
     - type: HTN
       rootTask:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -128,8 +128,10 @@
     name: ghost-role-information-slimes-name
     description: ghost-role-information-slimes-description
     rules: ghost-role-information-nonantagonist-rules
-    raffle:
-      settings: short
+    # harmony start: remove ghost role raffle from slimes
+    # raffle:
+    #   settings: short
+    # harmony end
   - type: Speech
     speechVerb: Slime
     speechSounds: Slime
@@ -167,8 +169,10 @@
     - type: GhostRole
       description: ghost-role-information-angry-slimes-description
       rules: ghost-role-information-angry-slimes-rules
-      raffle:
-        settings: short
+      # harmony start: remove ghost role raffle from slimes
+      # raffle:
+      #   settings: short
+      # harmony end
 
 - type: entity
   name: green slime
@@ -205,8 +209,10 @@
     - type: GhostRole
       description: ghost-role-information-angry-slimes-description
       rules: ghost-role-information-angry-slimes-rules
-      raffle:
-        settings: short
+      # harmony start: remove ghost role raffle from slimes
+      # raffle:
+      #   settings: short
+      # harmony end
 
 - type: entity
   name: yellow slime
@@ -242,5 +248,7 @@
     - type: GhostRole
       description: ghost-role-information-angry-slimes-description
       rules: ghost-role-information-angry-slimes-rules
-      raffle:
-        settings: short
+      # harmony start: remove ghost role raffle from slimes
+      # raffle:
+      #   settings: short
+      # harmony end


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removed the ghost role raffle from slimes, spiders, and the dragon's carps.
This means they can be played as almost instantly after they spawn.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the port of the vent critter rework from DeltaV, security is able to know the general area where the spiders and slimes are going to appear before they even spawn. This means there is a high chance for security to kill all of them before the raffle finishes which is sad for ghosts.

As for the dragon's carps, there are usually either over 10 in which case having a raffle is completely unnecessary or they are being spawn camped which leads to the same problem as slimes and spiders.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Pictured: blue slime, green slime, yellow slime, tarantula, clown spider, dragonbrood carp
![slime_raffle_removal](https://github.com/user-attachments/assets/8fab7bad-d337-4faa-ad26-449bffc181d8)


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Removed the ghost role raffle from slimes.
- tweak: Removed the ghost role raffle from spiders.
- tweak: Removed the ghost role raffle from the dragon's carps.