### PR TITLE
Roll antags before jobs.

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -627,6 +627,8 @@ namespace Content.Client.Lobby.UI
                 ("humanoid-profile-editor-antag-preference-no-button", 1)
             };
 
+            AntagList.AddChild(new Label { Text = Loc.GetString("humanoid-profile-editor-antag-roll-before-jobs") }); // Goobstation
+
             foreach (var antag in _prototypeManager.EnumeratePrototypes<AntagPrototype>().OrderBy(a => Loc.GetString(a.Name)))
             {
                 if (!antag.SetPreference)

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -182,6 +182,13 @@ public partial struct AntagSelectionDefinition()
     /// </remarks>
     [DataField]
     public EntProtoId? SpawnerPrototype;
+
+    /// <summary>
+    /// Goobstation
+    /// Does this antag role roll before job
+    /// </summary>
+    [DataField]
+    public bool RollBeforeJob = true;
 }
 
 /// <summary>

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server._Goobstation.PendingAntag;
 using Content.Server.Administration.Managers;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Station.Components;
@@ -17,6 +18,7 @@ public sealed partial class StationJobsSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IBanManager _banManager = default!;
+    [Dependency] private readonly PendingAntagSystem _pendingAntag = default!; // Goobstation
 
     private Dictionary<int, HashSet<string>> _jobsByWeight = default!;
     private List<int> _orderedWeights = default!;
@@ -290,7 +292,8 @@ public sealed partial class StationJobsSystem
             }
 
             var profile = profiles[player];
-            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow)
+            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow &&
+                !_pendingAntag.PendingAntags.ContainsKey(player)) // Goob edit - spawn as overflow if rolled antag
             {
                 assignedJobs.Add(player, (null, EntityUid.Invalid));
                 continue;
@@ -351,6 +354,8 @@ public sealed partial class StationJobsSystem
 
             List<string>? availableJobs = null;
 
+            var pendingAntag = _pendingAntag.PendingAntags.ContainsKey(player); // Goobstation
+
             foreach (var jobId in profileJobs)
             {
                 var priority = profile.JobPriorities[jobId];
@@ -359,6 +364,9 @@ public sealed partial class StationJobsSystem
                     continue;
 
                 if (!_prototypeManager.TryIndex(jobId, out var job))
+                    continue;
+
+                if (!job.CanBeAntag && pendingAntag) // Goobstation
                     continue;
 
                 if (weight is not null && job.Weight != weight.Value)

--- a/Content.Server/_Goobstation/PendingAntag/PendingAntagSystem.cs
+++ b/Content.Server/_Goobstation/PendingAntag/PendingAntagSystem.cs
@@ -1,0 +1,44 @@
+using Content.Server.Antag;
+using Content.Server.Antag.Components;
+using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Goobstation.PendingAntag;
+
+public sealed class PendingAntagSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly AntagSelectionSystem _selection = default!;
+
+    public Dictionary<NetUserId, (AntagSelectionDefinition, Entity<AntagSelectionComponent>)> PendingAntags = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawned);
+    }
+
+    private void OnPlayerSpawned(PlayerSpawnCompleteEvent ev)
+    {
+        if (ev.LateJoin)
+            return;
+
+        if (ev.JobId == null || !_prototypeManager.Index<JobPrototype>(ev.JobId).CanBeAntag)
+            return;
+
+        if (!PendingAntags.Remove(ev.Player.UserId, out var pendingAntag))
+            return;
+
+        _selection.TryMakeAntag(pendingAntag.Item2, ev.Player, pendingAntag.Item1, true);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        PendingAntags.Clear();
+    }
+}

--- a/Content.Shared/Antag/AntagAcceptability.cs
+++ b/Content.Shared/Antag/AntagAcceptability.cs
@@ -29,6 +29,12 @@ public enum AntagSelectionTime : byte
     PrePlayerSpawn,
 
     /// <summary>
+    /// Goobstation
+    /// Antag roles are assigned before jobs are assigned and during midround when player latejoins.
+    /// </summary>
+    BeforeJobs,
+
+    /// <summary>
     /// Antag roles get assigned after players have been assigned jobs and have spawned in.
     /// </summary>
     PostPlayerSpawn

--- a/Resources/Locale/en-US/_Goobstation/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Goobstation/preferences/ui/humanoid-profile-editor.ftl
@@ -1,0 +1,1 @@
+humanoid-profile-editor-antag-roll-before-jobs = Keep in mind that all antags except for initial infected and sleeper agent are rolled before jobs.

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -15,6 +15,7 @@
       maxPicks: 10
     maxDifficulty: 2.5
   - type: AntagSelection
+    selectionTime: BeforeJobs # Goobstation
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -175,6 +175,11 @@
   - type: GameRule
     minPlayers: 5
   - type: AntagSelection
+    # Harmony/Goobstation change: removing of delay is necessary for the entire "roll antag before jobs" system to work.
+    #delay:
+    #  min: 240
+    #  max: 420
+    # End of Harmony/Goobstation change.
     selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ Traitor ]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -174,9 +174,6 @@
   components:
   - type: GameRule
     minPlayers: 5
-    delay:
-      min: 240
-      max: 420
   - type: AntagSelection
     selectionTime: BeforeJobs # Goobstation
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -174,12 +174,12 @@
   components:
   - type: GameRule
     minPlayers: 5
-  - type: AntagSelection
     # Harmony/Goobstation change: removing of delay is necessary for the entire "roll antag before jobs" system to work.
     #delay:
     #  min: 240
     #  max: 420
     # End of Harmony/Goobstation change.
+  - type: AntagSelection
     selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ Traitor ]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -174,6 +174,9 @@
   components:
   - type: GameRule
     minPlayers: 5
+    delay:
+      min: 240
+      max: 420
   - type: AntagSelection
     selectionTime: BeforeJobs # Goobstation
     definitions:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -174,10 +174,8 @@
   components:
   - type: GameRule
     minPlayers: 5
-    delay:
-      min: 240
-      max: 420
   - type: AntagSelection
+    selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
       max: 8
@@ -198,6 +196,7 @@
     giveCodewords: false # It would actually give them a different set of codewords than the regular traitors, anyway
     giveBriefing: false
   - type: AntagSelection
+    selectionTime: PostPlayerSpawn # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
       mindRoles:
@@ -211,6 +210,7 @@
     minPlayers: 15
   - type: RevolutionaryRule
   - type: AntagSelection
+    selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
I did not write this PR. Everything is owned, written, etc. by the original creator at https://github.com/Goob-Station/Goob-Station/pull/1012
The game rolls antags before jobs now
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://github.com/Goob-Station/Goob-Station/pull/1012
Also this:
![image](https://github.com/user-attachments/assets/56409163-bdee-42d1-8be2-1e5b274e0c02)

## Technical details
<!-- Summary of code changes for easier review. -->
It's a direct port with some files missing as we're not using dynamic gamerules as well as people don't want the intern jobs to be able to roll antags. Comments indicating upstream files changes are left as is, except:
Resources\Prototypes\GameRules\roundstart.yml -- original PR removed the delay values. I readded and commented out them instead
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Antags are rolled before jobs now.
