### PR TITLE
Standardize spacefaring suit armor and speed values.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -496,7 +496,7 @@
         Blunt: 0.8 # 0.9 -> 0.8
         Slash: 0.8 # 0.9 -> 0.8
         Piercing: 0.8
-        # Radiation: 0.5
+        Radiation: 0.5
         Caustic: 0.5 # 0.8 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.85

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -12,15 +12,18 @@
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/basic.rsi
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
+  # Harmony - Remove explosion resistance.
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.9
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Caustic: 0.9
+        # Harmony - Change Resistances
+        # Blunt: 0.9
+        # Slash: 0.9
+        # Piercing: 0.9
+        Caustic: 0.5 # 0.9 -> O.5
+        # End Harmony
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
@@ -47,19 +50,25 @@
     coolingCoefficient: 0.001
   - type: FireProtection
     reduction: 0.8
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  # Harmony - Remove explosion resistance.
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.8
+        # Harmony - Change Resistances
+        # Blunt: 0.9
+        # Slash: 0.9
+        # Piercing: 0.9
+        Heat: 0.8 # 0.8 -> 0.6
+        Cold: 0.6 # 1.0 -> 0.6
+        Shock: 0.6 # 1.0 -> 0.6
+        Caustic: 0.5 # 1.0 -> 0.5
         Radiation: 0.5
-  - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+  # Harmony - Inherit 0.8 movement speed.
+  # - type: ClothingSpeedModifier
+  #   walkModifier: 0.7
+  #   sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitAtmos
@@ -78,20 +87,23 @@
   - type: PressureProtection
     highPressureMultiplier: 0.04
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.5
+  # Harmony - Remove explosion resistance.
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Shock: 0.8
+        # Harmony - Change resistances
+        # Blunt: 0.9
+        # Slash: 0.9
+        # Piercing: 0.9
+        Shock: 0.5 # 0.8 -> 0.5
         Caustic: 0.5
         Radiation: 0.2
-  - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.7
+  # Harmony - Inherit 0.8 movement speed.
+  # - type: ClothingSpeedModifier
+  #   walkModifier: 0.7
+  #   sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitEngineering
@@ -113,14 +125,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
-        Caustic: 0.8
+        # Harmony - Change resistances
+        Blunt: 0.8 # 0.9 -> 0.8
+        Slash: 0.8 # 0.9 -> 0.8
+        Piercing: 0.8 # 0.9 -> 0.8
+        Radiation: 0.5 # 0.3 -> 0.5
+        Caustic: 0.5 # 0.8 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.8
+    walkModifier: 0.85 # Harmony - 0.9 -> 0.85
+    sprintModifier: 0.85 # Harmony - 0.8 -> 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSpatio
@@ -139,16 +152,18 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.3
+  # Harmony - Remove explosion resistance.
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.3
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.5
-        Radiation: 0.3
-        Caustic: 0.7
+        # Harmony - Change resistances
+        Blunt: 0.6 # 0.7 -> 0.6
+        Slash: 0.6 # 0.7 -> 0.6
+        Piercing: 0.6 # 0.5 -> 0.6
+        Radiation: 0.5 # 0.3 -> 0.5
+        Caustic: 0.5 # 0.7 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -170,25 +185,25 @@
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+    walkModifier: 0.85 # Harmony - 1.0 -> 0.85
+    sprintModifier: 0.85 # Harmony - 1.0 -> 0.85
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.6
         Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.3
-        Radiation: 0.1
+        Piercing: 0.6 # 0.5 -> 0.6
+        # Heat: 0.3
+        Radiation: 0.5 # 0.1 -> 0.5
   - type: ExplosionResistance
-    damageCoefficient: 0.2
+    damageCoefficient: 0.8 # Harmony - 0.2 -> 0.8
   - type: TemperatureProtection
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitMaxim
 
-# Harmony change. Adjusted damage resistance values
 #Security Hardsuit
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseRestrictedContraband]
@@ -204,15 +219,16 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.5 # Harmony - 0.4 -> 0.5
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.8
-        Caustic: 0.7
+        Heat: 0.8 # 1.0 -> 0.8
+        Caustic: 0.5 # 0.7 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
@@ -234,20 +250,24 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  # Harmony - Add explosion resistance
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.7
+        Piercing: 0.8 # 0.7 -> 0.8
+        Caustic: 0.5 # 1.0 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.90 # Harmony - 0.65 -> 0.90
+    sprintModifier: 0.90 # Harmony - 0.65 -> 0.90
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
 
-# Harmony change. Adjusted damage resistance values
 #Warden's Hardsuit
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseRestrictedContraband]
@@ -263,15 +283,16 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.5 # Harmony - 0.4 -> 0.5
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.4
         Slash: 0.4
         Piercing: 0.4
-        Heat: 0.7
-        Caustic: 0.7
+        Heat: 0.6 # 1.0 -> 0.6
+        Caustic: 0.5 # 0.7 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.70
     sprintModifier: 0.70
@@ -298,15 +319,16 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
+        # Harmony - Change resistances
+        Blunt: 0.6 # 0.8 -> 0.6
+        Slash: 0.6 # 0.8 -> 0.6
         Piercing: 0.6
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+        Heat: 0.6 # 0.5 -> 0.6
+        # Radiation: 0.5
+        Caustic: 0.5 # 0.6 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.85 # Harmony - 0.8 -> 0.85
+    sprintModifier: 0.85 # Harmony - 0.8 -> 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCap
@@ -327,19 +349,23 @@
     lowPressureMultiplier: 1000
   - type: FireProtection
     reduction: 0.8
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+  # Harmony - Remove explosion resistance
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.2
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.8
-        Heat: 0.4
+        Heat: 0.5 # 0.4 -> 0.5
+        Cold: 0.5 # 1.0 -> 0.5
+        Shock: 0.5 # 1.0 -> 0.5
         Radiation: 0.0
-        Caustic: 0.7
+        Caustic: 0.5 # 0.7 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
+    walkModifier: 0.8 # Harmony - 0.75 -> 0.8
     sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -362,9 +388,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Caustic: 0.1
+        Caustic: 0.2 # Harmony - 0.1 -> 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.95 # Harmony - 0.9 -> 0.95
     sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -387,17 +413,18 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
+        # Harmony - Change resistances
+        Blunt: 0.8 # 0.6 -> 0.8
         Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.3
-        Radiation: 0.1
+        Piercing: 0.8 # 0.9 -> 0.8
+        Heat: 0.5 # 0.3 -> 0.5
+        Radiation: 0.4 # 0.1 -> 0.4
         Caustic: 0.2
   - type: ExplosionResistance
-    damageCoefficient: 0.1
+    damageCoefficient: 0.2 # Harmony - 0.1 -> 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8 # Harmony - 0.75 -> 0.8
+    sprintModifier: 0.8 # Harmony - 0.75 -> 0.8
   - type: HeldSpeedModifier
   - type: Item
     size: Huge
@@ -414,7 +441,6 @@
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitRd
 
-# Harmony change. Adjusted damage resistance values
 #Head of Security's Hardsuit
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
@@ -430,14 +456,15 @@
     highPressureMultiplier: 0.45
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.4
+    damageCoefficient: 0.5 # Harmony - 0.4 -> 0.5
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.5
         Slash: 0.5
         Piercing: 0.5
-        Heat: 0.75
+        Heat: 0.8 # 1.0 -> 0.8
         Caustic: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 0.85
@@ -465,14 +492,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
+        # Harmony - Change resistances
+        Blunt: 0.8 # 0.9 -> 0.8
+        Slash: 0.8 # 0.9 -> 0.8
         Piercing: 0.8
-        Radiation: 0.5
-        Caustic: 0.8
+        # Radiation: 0.5
+        Caustic: 0.5 # 0.8 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.9
+    sprintModifier: 0.85 # Harmony - 0.9 -> 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
@@ -563,12 +591,12 @@
         Slash: 0.6
         Piercing: 0.6
         Heat: 0.2
-        Radiation: 0.01
+        Radiation: 0.0 # Harmony - 0.01 -> 0.0, why was this even there?
         Caustic: 0.5
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
+    walkModifier: 0.9 # Harmony - 1.0 -> 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
@@ -593,12 +621,13 @@
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.4
         Slash: 0.4
-        Piercing: 0.3
-        Heat: 0.5
-        Radiation: 0.25
-        Caustic: 0.4
+        Piercing: 0.4 # 0.3 -> 0.4
+        Heat: 0.4 # 0.5 -> 0.4
+        Radiation: 0.5 # 0.25 -> 0.5
+        Caustic: 0.5 # 0.4 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -621,19 +650,20 @@
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.3
+    damageCoefficient: 0.2 # Harmony - 0.3 -> 0.2
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.2
         Slash: 0.2
         Piercing: 0.2
         Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
+        Radiation: 0.5 # 0.2 -> 0.5
+        Caustic: 0.5 # 0.2 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.65
+    walkModifier: 0.7 # Harmony - 0.9 -> 0.7
+    sprintModifier: 0.7 # Harmony - 0.65 -> 0.7
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersun
@@ -657,12 +687,13 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
-        Heat: 0.25
-        Radiation: 0.25
-        Caustic: 0.75
+        # Harmony - Change resistances
+        Blunt: 0.5 # 0.6 -> 0.5
+        Slash: 0.5 # 0.6 -> 0.5
+        Piercing: 0.5 # 0.4 -> 0.5
+        Heat: 0.5 # 0.25 -> 0.5
+        Radiation: 0.5 # 0.25 -> 0.5
+        Caustic: 0.5 # 0.75 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -684,15 +715,17 @@
   - type: PressureProtection
     highPressureMultiplier: 0.225
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.2
+  # Harmony - Remove explosion resistance
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.2
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 1
-        Heat: 0.5
+        # Harmony - Change resistances
+        # Blunt: 0.95
+        # Slash: 0.95
+        # Piercing: 1 - bruh
+        # Heat: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -714,18 +747,19 @@
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.7
+    damageCoefficient: 0.5 # Harmony - 0.7 -> 0.5
   - type: Armor
     modifiers:
       coefficients:
+        # Harmony - Change resistances
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.4
-        Caustic: 0.75
+        Piercing: 0.8 # 0.9 -> 0.8
+        Heat: 0.5 # 0.4 -> 0.5
+        Caustic: 0.5 # 0.75 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.6
-    sprintModifier: 0.6
+    walkModifier: 0.9 # Harmony - 0.6 -> 0.9
+    sprintModifier: 0.9 # Harmony - 0.6 -> 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateEVA
@@ -747,18 +781,19 @@
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.6
+    damageCoefficient: 0.5 # Harmony - 0.6 -> 0.5
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.8
-        Piercing: 0.85
+        # Harmony - Change resistances
+        Blunt: 0.6 # 0.7 -> 0.6
+        Slash: 0.6 # 0.8 -> 0.6
+        Piercing: 0.6 # 0.85 -> 0.6
         Heat: 0.4
-        Caustic: 0.75
+        Caustic: 0.5 # 0.6 -> 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
+    walkModifier: 0.9 # Harmony - 0.8 -> 0.9
+    sprintModifier: 0.9 # Harmony - 0.8 -> 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitPirateCap
@@ -854,6 +889,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTJanitor
 
+# Harmony - Technically this should get changed to 0.2s but I don't really want to touch this.
 #Deathsquad
 - type: entity
   parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
@@ -909,21 +945,22 @@
     heatingCoefficient: 0.001
     coolingCoefficient: 0.001
   - type: ExplosionResistance
-    damageCoefficient: 0.7
+    damageCoefficient: 0.6 # Harmony - 0.7 -> 0.6
   - type: Armor
     modifiers:
+      # Harmony - Change resistances
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
+        Blunt: 0.6 # 0.7 -> 0.6
+        Slash: 0.6 # 0.7 -> 0.6
         Piercing: 0.6
-        Heat: 0.1
-        Cold: 0.1
-        Shock: 0.1
-        Radiation: 0.1
-        Caustic: 0.1
+        Heat: 0.2 # 0.1 -> 0.2
+        Cold: 0.2 # 0.1 -> 0.2
+        Shock: 0.2 # 0.1 -> 0.2
+        # Radiation: 0.1
+        Caustic: 0.0 # 0.1 -> 0.0
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+    walkModifier: 0.9 # Harmony - 1.0 -> 0.9
+    sprintModifier: 0.9 # Harmony - 1.0 -> 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURN
@@ -943,18 +980,19 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Caustic: 0.8
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+  # Harmony - Remove resistances and speed modifiers
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.9
+  # - type: Armor
+  #   modifiers:
+  #     coefficients:
+  #       Blunt: 0.9
+  #       Slash: 0.9
+  #       Piercing: 0.9
+  #       Caustic: 0.8
+  # - type: ClothingSpeedModifier
+  #   walkModifier: 0.9
+  #   sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: Construction
     graph: ClownHardsuit
@@ -993,18 +1031,19 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.85
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.9
-        Piercing: 0.85
-        Caustic: 0.8
+  # Harmony - Remove resistances
+  # - type: ExplosionResistance
+  #   damageCoefficient: 0.85
+  # - type: Armor
+  #   modifiers:
+  #     coefficients:
+  #       Blunt: 0.85
+  #       Slash: 0.9
+  #       Piercing: 0.85
+  #       Caustic: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95 # Harmony - 0.9 -> 0.95
+    sprintModifier: 0.95 # Harmony - 0.9 -> 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSanta

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -115,9 +115,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Heat: 0.90
-        Radiation: 0.75
-        Caustic: 0.5
+        # Harmony - Change resistances
+        # Heat: 0.90
+        # Radiation: 0.75
+        Caustic: 0.2 # 0.5 -> 0.2
+        # End Harmony
   - type: GroupExamine
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitVoidParamed

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -60,12 +60,15 @@
   - type: Armor
     modifiers:
       coefficients:
-        Slash: 0.9
-        Heat: 0.8
-        Cold: 0.8
+        # Harmony - Change resistances
+        # Slash: 0.9
+        Heat: 0.6 # 0.8 -> 0.6
+        Cold: 0.6 # 0.8 -> 0.6
+        Shock: 0.6 # 1.0 -> 0.6
+        Caustic: 0.5 # 1.0 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.8
-    sprintModifier: 0.7
+    sprintModifier: 0.8 # Harmony - 0.7 -> 0.8
   - type: HeldSpeedModifier
   - type: GroupExamine
   - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -60,15 +60,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        # Harmony - Change resistances
-        # Slash: 0.9
-        Heat: 0.6 # 0.8 -> 0.6
-        Cold: 0.6 # 0.8 -> 0.6
-        Shock: 0.6 # 1.0 -> 0.6
-        Caustic: 0.5 # 1.0 -> 0.5
+        Slash: 0.9
+        Heat: 0.8
+        Cold: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.8
-    sprintModifier: 0.8 # Harmony - 0.7 -> 0.8
+    sprintModifier: 0.7
   - type: HeldSpeedModifier
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
@@ -95,9 +92,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Slash: 0.9
-        Heat: 0.8
-        Cold: 0.8
+        # Harmony - Change resistances
+        # Slash: 0.9
+        Heat: 0.6 # 0.8 -> 0.6
+        Cold: 0.6 # 0.8 -> 0.6
+        Shock: 0.6 # 1.0 -> 0.6
+        Caustic: 0.5 # 1.0 -> 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -299,5 +299,9 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.01
     coolingCoefficient: 0.01
+  # Harmony - Add slowdown
+  - type: ClothingSpeedModifier
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCarp


### PR DESCRIPTION
## About the PR
First part of the armorening.
Standardize hardsuit, softsuit and some other spacefaring suit's values. 

## Why / Balance
Armor values are currently a mess. Many suits had resistances that they did not need, and many had minor changes in resistances that just made it harder to interact with them. A lot of them also had wildly inconsistant walking speeds (For some reason, the juggernatu suit's walk modifier was 90%, which made its walking speed the same as its running speed?)

This PR aims to make things more standard across the board, at least for the suits I did touch. Armor values were uniformized across their damage types + now increment cleanly, and any difference in walking vs running speed was squashed.

This PR is not trying to "rebalance" hardsuits, just to standardize them. I did remove some resistances (the most notable is the CE losing their 80% explosion resistance), but the overall balance should be more or less the same.

Here is a spreadsheet of old VS new values (pre-heat res on sec):
![image](https://github.com/user-attachments/assets/37874c69-aae5-4b6d-952b-bdbe460ad6ca)


## Technical details
Just YML

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Jajsha
- tweak: Standardized armor values. 

