### PR TITLE
Fixes pod docking bugs, remove externals access from pods.

### DIFF
--- a/Content.Server/Shuttles/Components/DockingComponent.cs
+++ b/Content.Server/Shuttles/Components/DockingComponent.cs
@@ -18,14 +18,6 @@ namespace Content.Server.Shuttles.Components
         [ViewVariables]
         public override bool Docked => DockedWith != null;
 
-        // Harmony
-        /// <summary>
-        /// True if there is currently a grid in FTL trying to dock here.
-        /// </summary>
-        [DataField]
-        public bool QueuedDocked = false;
-        // End Harmony
-
         /// <summary>
         /// Color that gets shown on the radar screen.
         /// </summary>

--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -289,7 +289,7 @@ public sealed partial class DockingSystem
         // Prioritise by priority docks, then by maximum connected ports, then by most similar angle.
         // Harmony - Make sure the dock is not already an FTL target
         validDockConfigs = validDockConfigs
-           .Where(x => x.Docks.All(y => !y.DockA.QueuedDocked && !y.DockB.QueuedDocked)) // Harmony
+           .OrderByDescending(x => x.Docks.All(y => !y.DockA.QueuedDocked && !y.DockB.QueuedDocked)) // Harmony
            .OrderByDescending(x => IsConfigPriority(x, priorityTag))
            .ThenByDescending(x => x.Docks.Count)
            .ThenBy(x => Math.Abs(Angle.ShortestDistance(x.Angle.Reduced(), targetGridAngle).Theta)).ToList();

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -333,6 +333,7 @@ public sealed partial class ShuttleSystem
             // Harmony - Mark the docks as queued for a docking
             config.Docks.ForEach(x =>
             {
+                hyperspace.Docks.AddRange([x.DockA, x.DockB]);
                 x.DockA.QueuedDocked = true;
                 x.DockB.QueuedDocked = true;
             });
@@ -512,6 +513,10 @@ public sealed partial class ShuttleSystem
             var config = _dockSystem.GetDockingConfigAt(uid, target.EntityId, target, entity.Comp1.TargetAngle);
             var mapCoordinates = _transform.ToMapCoordinates(target);
 
+            // Harmony - Mark the docks as unqueued
+            entity.Comp1.Docks.ForEach(x => x.QueuedDocked = false);
+            // End Harmony
+
             // Couldn't dock somehow so just fallback to regular position FTL.
             if (config == null)
             {
@@ -520,13 +525,6 @@ public sealed partial class ShuttleSystem
             else
             {
                 FTLDock((uid, xform), config);
-                // Harmony - Mark the docks as unqueued
-                config.Docks.ForEach(x =>
-                {
-                    x.DockA.QueuedDocked = false;
-                    x.DockB.QueuedDocked = false;
-                });
-                // End Harmony
             }
 
             mapId = mapCoordinates.MapId;

--- a/Content.Shared/Shuttles/Components/FTLComponent.cs
+++ b/Content.Shared/Shuttles/Components/FTLComponent.cs
@@ -44,6 +44,14 @@ public sealed partial class FTLComponent : Component
     [DataField, AutoNetworkedField]
     public Angle TargetAngle;
 
+    //Harmony
+    /// <summary>
+    /// All docks involved in this FTL operation.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<SharedDockingComponent> Docks = new List<SharedDockingComponent>();
+    //End Harmony
+
     /// <summary>
     /// If we're docking after FTL what is the prioritised dock tag (if applicable).
     /// </summary>

--- a/Content.Shared/Shuttles/Components/SharedDockingComponent.cs
+++ b/Content.Shared/Shuttles/Components/SharedDockingComponent.cs
@@ -6,5 +6,13 @@ namespace Content.Shared.Shuttles.Components
         // and I was too lazy to delete it.
 
         public abstract bool Docked { get; }
+
+        // Harmony
+        /// <summary>
+        /// True if there is currently a grid in FTL trying to dock here.
+        /// </summary>
+        [DataField]
+        public bool QueuedDocked = false;
+        // End Harmony
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -1265,7 +1265,7 @@
       - HideLabel
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsExternal ]
+      board: [ DoorElectronics ]
 
 #HighSecDoors
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Fixes bug where a shuttle failing to dock where it wanted to failed to unmark the proper docks as queued.
Makes shuttles still try to launch even if there is no unqueued dock.
Removes access requirements from evacuation pods

## Why / Balance
Fixing bugs is cool
Evac pod doors tend to sometimes unbolt and close for some reason, which is weird. You should always be able to get into an evac pod.

## Technical details
Added a new Docks argument to the FTL component that is used to store which docks the FTL action is queueing. 
Insted of unqueueing the docks which the shuttle docked too on FTL end, it unqueues the ones it *should* have FTLed to.


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Jajsha
- tweak: Evacuation Pod Doors are no longer externals locked.
