### PR TITLE
RCD ammo usage / RCD and Compressed Matter Price changes

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -114,7 +114,7 @@
     sprite: Objects/Tools/rcd.rsi
     state: ammo
   product: CrateRCDAmmo
-  cost: 2500
+  cost: 3000
   category: cargoproduct-category-name-engineering
   group: market
 
@@ -124,7 +124,7 @@
     sprite: Objects/Tools/rcd.rsi
     state: icon
   product: CrateRCD
-  cost: 800
+  cost: 1500
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -114,7 +114,8 @@
     sprite: Objects/Tools/rcd.rsi
     state: ammo
   product: CrateRCDAmmo
-  cost: 3000
+  #cost: 2500
+  cost: 3000 #Harmony
   category: cargoproduct-category-name-engineering
   group: market
 
@@ -124,7 +125,8 @@
     sprite: Objects/Tools/rcd.rsi
     state: icon
   product: CrateRCD
-  cost: 1500
+  #cost: 800
+  cost: 1500 # Harmony
   category: cargoproduct-category-name-engineering
   group: market
 

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -16,7 +16,7 @@
   id: DeconstructLattice   # Hidden prototype - do not add to RCDs  
   name: rcd-component-deconstruct
   mode: Deconstruct
-  cost: 2
+  cost: 1
   delay: 0
   rotation: Camera
   fx: EffectRCDConstruct0
@@ -93,7 +93,7 @@
   sprite: /Textures/Interface/Radial/RCD/grille.png
   mode: ConstructObject
   prototype: Grille
-  cost: 4
+  cost: 1
   delay: 2
   collisionMask: Impassable
   rotation: Fixed
@@ -106,7 +106,7 @@
   sprite: /Textures/Interface/Radial/RCD/window.png
   mode: ConstructObject
   prototype: Window
-  cost: 3
+  cost: 2
   delay: 2
   collisionMask: Impassable
   rules:
@@ -135,7 +135,7 @@
   sprite: /Textures/Interface/Radial/RCD/window_reinforced.png
   mode: ConstructObject
   prototype: ReinforcedWindow
-  cost: 4
+  cost: 3
   delay: 3
   collisionMask: Impassable
   rules:
@@ -165,7 +165,7 @@
   sprite: /Textures/Interface/Radial/RCD/airlock.png
   mode: ConstructObject
   prototype: Airlock
-  cost: 4
+  cost: 6
   delay: 4
   collisionMask: FullTileMask
   rotation: Camera
@@ -177,7 +177,7 @@
   sprite: /Textures/Interface/Radial/RCD/glass_airlock.png
   mode: ConstructObject
   prototype: AirlockGlass
-  cost: 4
+  cost: 8
   delay: 4
   collisionMask: FullTileMask
   rotation: Camera

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -16,7 +16,8 @@
   id: DeconstructLattice   # Hidden prototype - do not add to RCDs  
   name: rcd-component-deconstruct
   mode: Deconstruct
-  cost: 1
+  #cost: 2
+  cost: 1 # Harmony
   delay: 0
   rotation: Camera
   fx: EffectRCDConstruct0
@@ -93,7 +94,8 @@
   sprite: /Textures/Interface/Radial/RCD/grille.png
   mode: ConstructObject
   prototype: Grille
-  cost: 1
+  #cost: 4
+  cost: 1 # Harmony
   delay: 2
   collisionMask: Impassable
   rotation: Fixed
@@ -106,7 +108,8 @@
   sprite: /Textures/Interface/Radial/RCD/window.png
   mode: ConstructObject
   prototype: Window
-  cost: 2
+  #cost: 3
+  cost: 2 # Harmony
   delay: 2
   collisionMask: Impassable
   rules:
@@ -135,7 +138,8 @@
   sprite: /Textures/Interface/Radial/RCD/window_reinforced.png
   mode: ConstructObject
   prototype: ReinforcedWindow
-  cost: 3
+  #cost: 4
+  cost: 3 # Harmony
   delay: 3
   collisionMask: Impassable
   rules:
@@ -149,7 +153,8 @@
   sprite: /Textures/Interface/Radial/RCD/directional_reinforced.png
   mode: ConstructObject
   prototype: WindowReinforcedDirectional
-  cost: 3
+  #cost: 4
+  cost: 3 # Harmony
   delay: 2
   collisionMask: Impassable
   collisionBounds: "-0.23,-0.49,0.23,-0.36"
@@ -165,7 +170,8 @@
   sprite: /Textures/Interface/Radial/RCD/airlock.png
   mode: ConstructObject
   prototype: Airlock
-  cost: 6
+  #cost: 4
+  cost: 6 # Harmony
   delay: 4
   collisionMask: FullTileMask
   rotation: Camera
@@ -177,7 +183,8 @@
   sprite: /Textures/Interface/Radial/RCD/glass_airlock.png
   mode: ConstructObject
   prototype: AirlockGlass
-  cost: 8
+  #cost: 4
+  cost: 8 # Harmony
   delay: 4
   collisionMask: FullTileMask
   rotation: Camera


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->

## About the PR
Based almost entirely by the work of @yotaxp on the discord, in their discussion thread of this very topic.

## Why / Balance
As stated in the thread (https://discord.com/channels/1139716325627932682/1335427764244713493) RCD usage of ammo, and the prices for restocking did not reflect the cost of the actual materials required to craft them by hand. The most significant changes are making Grilles (which cost one steel) cheaper, and Glass Airlocks 

## Media
![costs](https://github.com/user-attachments/assets/e2c64190-7abb-4ebc-a1bc-685c9b19b5a2)

<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: The RCD and Compressed Matter for it now cost more at a Cargo Request Console.
- tweak: RCD ammo usage has been changed to reflect material costs of certain objects.
-->
