### PR TITLE
Disable Default Station Rotation

### DIFF
--- a/Content.Server/Maps/GameMapPrototype.cs
+++ b/Content.Server/Maps/GameMapPrototype.cs
@@ -26,7 +26,7 @@ public sealed partial class GameMapPrototype : IPrototype
     public float MaxRandomOffset = 1000f;
 
     [DataField]
-    public bool RandomRotation = true;
+    public bool RandomRotation = false; // Harmony change for QOL, default is true.
 
     /// <summary>
     /// Name of the map to use in generic messages, like the map vote.


### PR DESCRIPTION
## About the PR
Makes the station start un-rotated and aligned with map rotation.

## Why / Balance
The station being randomly rotated causes unnecessary confusion for salvagers and others outside of the station, and even admins to a minor extent while using a mass scanner. Round start rotation and offset was added to dissuade contributors from using absolute position values. This was rarely an issue for salvagers when the reclaimer existed, but now causes problems that I would never describe as a skill issue. PR only changes rotation and not starting offset (station will not be at 0,0), and station can still be moved off axis if the anchor is disabled.

## Technical details
`Content.Server/Maps/GameMapPrototype.cs` RandomRotation changed from true to false.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The station will now start rotationally aligned to space.