### PR TITLE
Adjust Role Timers

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -12,9 +12,9 @@
       time: 0 #0 hrs
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 10800 #3 hours
+      time: 28800 #8 hours
     - !type:OverallPlaytimeRequirement
-      time: 10800 #3 hrs
+      time: 43200 #12 hrs
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -6,16 +6,16 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 0 # 0 hours
+      time: 7200 # 2 hours
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 0 # 0 hours
+      time: 7200 # 2 hours
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 0 # 0 hours
+      time: 7200 # 2 hours
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 10800 # 3 hours
+      time: 21600 # 6 hours
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -14,8 +14,11 @@
       department: Security
       time: 0 # 0 hrs
     - !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 14400 # 4 hrs
+    - !type:DepartmentTimeRequirement
       department: Command
-      time: 10800 # 3 hours
+      time: 14400 # 4 hours
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -12,9 +12,9 @@
       time: 0 #0hrs
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 10800 #3 hrs
+      time: 28800 #8 hrs
     - !type:OverallPlaytimeRequirement
-      time: 10800 #3 hrs
+      time: 43200 #12 hrs
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -14,9 +14,9 @@
       time: 0 #0 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 10800 #3 hrs
+      time: 28800 #8 hrs
     - !type:OverallPlaytimeRequirement
-      time: 10800 #3 hrs
+      time: 43200 #12 hrs
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -6,7 +6,7 @@
   playTimeTracker: JobStationAi
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 10800  # 3 hrs
+    time: 28800  # 8 hrs
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd
@@ -21,7 +21,7 @@
   playTimeTracker: JobBorg
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 0 # 60 hrs
+      time: 14400 # 4 hrs
   canBeAntag: false
   icon: JobIconBorg
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -6,9 +6,9 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 10800 #3 hrs
+      time: 28800 #8 hrs
     - !type:OverallPlaytimeRequirement
-      time: 10800 #3hrs
+      time: 43200 #12hrs
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 0 # 15 hours
+      time: 7200 # 2 hours
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,15 +6,15 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 0 #0hrs
+      time: 10800 #3hrs
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 0 #0 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 10800 # 3 hrs
+      time: 36000 #10 hrs
     - !type:OverallPlaytimeRequirement
-      time: 10800 #3 hrs
+      time: 43200 #12 hrs
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobSecurityCadet
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 0 #10 hrs
+      time: 3600 #1 hrs
     - !type:DepartmentTimeRequirement
       department: Security
       time: 54000 #15 hrs

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 0 #10 hrs
+      time: 3600 #1 hrs
   startingGear: SecurityOfficerGear
   icon: "JobIconSecurityOfficer"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 10800 # 30 hrs
+      time: 14400 # 4 hrs
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
## About the PR
Increased job requirements of most command jobs to 8 hours in department and 12 hours of overall playtime. Minor other changes, advise reading files.

## Why / Balance
General overall community/staff sentiment to make command more restrictive to play, especially security. Numbers based on staff discussion and reinforced by in-game polls. Aim is to increase command competence and prevent new and/or malicious players from rushing to roles with power.

## Technical details
Multiple job files changed in `Resources/Prototypes/Roles/Jobs/`

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Increased role timers for command and security.
