### PR TITLE
Reorganize PostMapInitTest.cs

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -45,6 +45,13 @@ namespace Content.IntegrationTests.Tests
 
         private static readonly string[] GameMaps =
         {
+            "dm01-entryway", // Harmony, deathmatch PROMOD map by Unisol
+            "dm02-sandbomb", // Harmony, deathmatch PROMOD map by Unisol
+            "Xeno", // Harmony, playtest for upstream by SlamBamActionman
+            "Barratry", // Harmony, revived by Spanky
+            "Aspid", // Harmony, playtest for upstream by Golinth
+            "Atlas", // Harmony revived by Kravin
+            "Mira" // Harmony, developed by tanuko
             "Dev",
             "TestTeg",
             "Fland",
@@ -62,19 +69,12 @@ namespace Content.IntegrationTests.Tests
             "Train",
             "Oasis",
             "Cog",
-            "Xeno", // Xeno map playtest
-            "Barratry", // Update of old map
-            "dm01-entryway", // deathmatch PROMOD map
-            "dm02-sandbomb", // deathmatch PROMOD map, Harmony change
-            "Aspid", // Pseudo playtest, not merged to upstream yet.
-            "Atlas", // Update of Atlas. Back from the grave!
             "Gate",
             "Amber",
             "Loop",
             "Plasma",
             "Elkridge",
             "Convex",
-            "Mira" // Mira Map Playtesting! ¡Viva!
 
         };
 

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -51,7 +51,7 @@ namespace Content.IntegrationTests.Tests
             "Barratry", // Harmony, revived by Spanky
             "Aspid", // Harmony, playtest for upstream by Golinth
             "Atlas", // Harmony revived by Kravin
-            "Mira" // Harmony, developed by tanuko
+            "Mira", // Harmony, developed by tanuko
             "Dev",
             "TestTeg",
             "Fland",
@@ -74,7 +74,7 @@ namespace Content.IntegrationTests.Tests
             "Loop",
             "Plasma",
             "Elkridge",
-            "Convex",
+            "Convex"
 
         };
 


### PR DESCRIPTION
## About the PR
Reorganizes Harmony's maps to the top of their list in `PostMapInitTest.cs` for cleanliness.

## Why / Balance
The maps were starting to get jumbled a bit with upstream merges and this should keep them all clean and prevent future merge conflicts.

## Technical details
Shifted lines of code in `PostMapInitTest.cs`

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.