### PR TITLE
Reverts disabler buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -21,6 +21,7 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: Battery
+  - type: Battery
     maxCharge: 1000
     startingCharge: 1000
   - type: MagazineVisuals
@@ -468,8 +469,7 @@
       - Belt
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    #fireCost: 50
-    fireCost: 100  # Harmony Change - Reverts to Pre-Buff
+    fireCost: 100  #Harmony Change - Reverts Disabler buff (100 -> 50)
   - type: GuideHelp
     guides:
     - Security
@@ -496,8 +496,7 @@
         shader: unshaded
   - type: Gun
     selectedMode: FullAuto
-    #fireRate: 4.5
-    fireRate: 4 # Harmony Change - Reverts to Pre-Buff
+    fireRate: 4 # Harmony Change - Reverts to Pre-Buff (4.5 -> 4)
     availableModes:
       - SemiAuto
       - FullAuto
@@ -505,8 +504,7 @@
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerSmg
-    #fireCost: 25
-    fireCost: 33 # Harmony Change - Reverts to Pre-Buff
+    fireCost: 33 # Harmony Change - Reverts to Pre-Buff (25 -> 33)
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -21,7 +21,6 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser.ogg
   - type: Battery
-  - type: Battery
     maxCharge: 1000
     startingCharge: 1000
   - type: MagazineVisuals

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -440,8 +440,7 @@
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerPractice
-    # fireCost: 50
-    fireCost: 100  # Harmony Change - Reverts to Pre-Buff
+    fireCost: 100  #Harmony Change - Reverts Disabler buff (100 -> 50)
   - type: Tag
     tags:
     - Taser

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -439,7 +439,8 @@
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerPractice
-    fireCost: 50  # Harmony Change - Reverts to Pre-Buff
+    # fireCost: 50
+    fireCost: 100  # Harmony Change - Reverts to Pre-Buff
   - type: Tag
     tags:
     - Taser
@@ -468,7 +469,7 @@
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
     #fireCost: 50
-    firecost: 100  # Harmony Change - Reverts to Pre-Buff
+    fireCost: 100  # Harmony Change - Reverts to Pre-Buff
   - type: GuideHelp
     guides:
     - Security

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -434,12 +434,12 @@
     price: 100
   - type: Gun
     fireRate: 2
-    projectileSpeed: 35 # any higher and this causes issues in lag
+    #projectileSpeed: 35 # any higher and this causes issues in lag
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerPractice
-    fireCost: 50
+    fireCost: 50  # Harmony Change - Reverts to Pre-Buff
   - type: Tag
     tags:
     - Taser
@@ -467,7 +467,8 @@
       - Belt
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 50
+    #fireCost: 50
+    firecost: 100  # Harmony Change - Reverts to Pre-Buff
   - type: GuideHelp
     guides:
     - Security
@@ -494,7 +495,8 @@
         shader: unshaded
   - type: Gun
     selectedMode: FullAuto
-    fireRate: 4.5
+    #fireRate: 4.5
+    fireRate: 4 # Harmony Change - Reverts to Pre-Buff
     availableModes:
       - SemiAuto
       - FullAuto
@@ -502,7 +504,8 @@
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerSmg
-    fireCost: 25
+    #fireCost: 25
+    fireCost: 33 # Harmony Change - Reverts to Pre-Buff
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -229,8 +229,7 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    #damage: 33
-    damage: 30  # Harmony Change - Reverts to Pre-Buff
+    damage: 30  # Harmony Change - Reverts to Pre-Buff (33 -> 30)
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -229,7 +229,8 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    damage: 33
+    #damage: 33
+    damage: 30  # Harmony Change - Reverts to Pre-Buff
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
I reverted [#34890](https://github.com/space-wizards/space-station-14/pull/34890), changing disablers back to their orignal state

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
__"Disablers are actually awful. Probably the worst performing I've seen them across Space Station history."_ - keronshb_


while disabler smgs and disablers have been under utilized for quite a while, I think that making them better ranged stun batons wasnt the answer, and while the disablers does need changes, this is just not it.
## Technical details
<!-- Summary of code changes for easier review. -->
Edited Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml - Reverted Disabler Changes
Edited Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml - Reverted Disabler Changes
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/c087000e-df51-4fa1-a34c-9f1b211561ff)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Reverted the disabler buff, rejoice.

