### PR TITLE
Magnum Speedloaders are now 1x1 (My totally original idea)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -18,6 +18,10 @@
     containers:
       ballistic-ammo: !type:Container
         ents: []
+  # Harmony Start
+  - type: Item
+    size: Tiny
+  # Harmony END
 
 - type: entity
   id: SpeedLoaderMagnum


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Totally didnt swipe this from someone else. Changes Speedloaders to be 1x1.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes Revolvers more viable, currently they arent a good weapon for people with trash aim.
## Technical details
<!-- Summary of code changes for easier review. -->
Edited Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml - Adjusted size of magnum ammo
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

![image](https://github.com/user-attachments/assets/5b87c4b2-7b71-4c52-a427-32bb65d78b5e)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed Magnum Speedloaders to be 1x1 instead of 1x2

