### PR TITLE
Salvover: Replaces the WT and Enforcer creates with Drozd and Kammerer crates

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,7 +1,7 @@
 - type: cargoProduct
   id: ArmorySmg
   icon:
-    sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
+    sprite: Objects/Weapons/Guns/SMGs/drozd.rsi # Harmony Change: Updated icon to match the item in the crate
     state: icon
   product: CrateArmorySMGHarmony  # Harmony Change: WT550s the drozds with kammerers in the SMG crate
   cost: 9000
@@ -11,7 +11,7 @@
 - type: cargoProduct
   id: ArmoryShotgun
   icon:
-    sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
+    sprite: Objects/Weapons/Guns/Shotguns/pump.rsi  # Harmony Change: Updated icon to match the item in the crate
     state: icon
   product: CrateArmoryShotgunHarmony # Harmony Change: Replaces the enforcers with kammerers in the shotgun crate
   cost: 7000

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,9 +1,15 @@
 - type: cargoProduct
   id: ArmorySmg
   icon:
-    sprite: Objects/Weapons/Guns/SMGs/drozd.rsi # Harmony Change: Updated icon to match the item in the crate
+# Start of Harmony Change: Updated icon to match the item in the crate
+    # sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
+    sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
+# End of Harmony Change
     state: icon
-  product: CrateArmorySMGHarmony  # Harmony Change: WT550s the drozds with kammerers in the SMG crate
+# Start of Harmony Change: Replaces the WTs with Drozds in the SMG crate
+  # product: CrateArmorySMG
+  product: CrateArmorySMGHarmony
+# End of Harmony Change
   cost: 9000
   category: cargoproduct-category-name-armory
   group: market
@@ -11,9 +17,15 @@
 - type: cargoProduct
   id: ArmoryShotgun
   icon:
-    sprite: Objects/Weapons/Guns/Shotguns/pump.rsi  # Harmony Change: Updated icon to match the item in the crate
+# Start of Harmony Change: Updated icon to match the item in the crate
+    # sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
+    sprite: Objects/Weapons/Guns/Shotguns/pump.rsi
+# End of Harmony Change
     state: icon
-  product: CrateArmoryShotgunHarmony # Harmony Change: Replaces the enforcers with kammerers in the shotgun crate
+# Start of Harmony Change: Replaces the Enforcers with Kammerers in the shotgun crate
+  # product: CrateArmoryShotgun
+  product: CrateArmoryShotgunHarmony
+# End of Harmony Change
   cost: 7000
   category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -3,7 +3,7 @@
   icon:
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
-  product: CrateArmorySMG
+  product: CrateArmorySMGHarmony  # Harmony Change: WT550s the drozds with kammerers in the SMG crate
   cost: 9000
   category: cargoproduct-category-name-armory
   group: market
@@ -13,7 +13,7 @@
   icon:
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
     state: icon
-  product: CrateArmoryShotgun
+  product: CrateArmoryShotgunHarmony # Harmony Change: Replaces the enforcers with kammerers in the shotgun crate
   cost: 7000
   category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -60,9 +60,15 @@
     CratePartsT4: 1.0
     PowerCellAntiqueProto: 0.25
     # basic weapons
-    CrateArmorySMGHarmony: 1.0 # Harmony Change: Updates the SMG crate spawn to be consistent with what can be bought from the cargo request computer
+# Start of Harmony Change: Updates the SMG crate spawn to be consistent with what can be bought from the cargo request computer
+    CrateArmorySMGHarmony: 1.0
+  #  CrateArmorySMG: 1.0
+# End of Harmony Change
     CrateArmoryLaser: 1.0
-    CrateArmoryShotgunHarmony: 1.0 # Harmony Change: Updates the shotgun crate spawn to be consistent with what can be bought from the cargo request computer
+# Start of Harmony Change: Updates the shotgun crate spawn to be consistent with what can be bought from the cargo request computer
+    CrateArmoryShotgunHarmony: 1.0
+  # CrateArmoryShotgun: 1.0
+# End of Harmony Change
     CrateArmoryPistols: 1.0
     # rare armor
     ClothingOuterArmorRiot: 1.0

--- a/Resources/Prototypes/Procedural/salvage_rewards.yml
+++ b/Resources/Prototypes/Procedural/salvage_rewards.yml
@@ -60,9 +60,9 @@
     CratePartsT4: 1.0
     PowerCellAntiqueProto: 0.25
     # basic weapons
-    CrateArmorySMG: 1.0
+    CrateArmorySMGHarmony: 1.0 # Harmony Change: Updates the SMG crate spawn to be consistent with what can be bought from the cargo request computer
     CrateArmoryLaser: 1.0
-    CrateArmoryShotgun: 1.0
+    CrateArmoryShotgunHarmony: 1.0 # Harmony Change: Updates the shotgun crate spawn to be consistent with what can be bought from the cargo request computer
     CrateArmoryPistols: 1.0
     # rare armor
     ClothingOuterArmorRiot: 1.0

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
@@ -61,7 +61,7 @@
 
 - type: entity
   id: CrateArmoryShotgunHarmony
-  suffic: kammerer
+  suffix: Kammerer
   parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
   name: shotgun crate
   description: For when the enemy absolutely needs to be replaced with lead. Contains two Kammerer Shotguns, and some standard shotgun shells. Requires Armory access to open.

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
@@ -56,8 +56,6 @@
     contents:
       - id: WeaponSubMachineGunDrozd
         amount: 2
-      - id: MagazinePistolSubMachineGun
-        amount: 4
 
 - type: entity
   id: CrateArmoryShotgunHarmony
@@ -70,5 +68,3 @@
     contents:
       - id: WeaponShotgunKammerer
         amount: 2
-      - id: BoxLethalshot
-        amount: 4

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
@@ -44,3 +44,31 @@
       - id: SpeedLoaderLightRifle
         orGroup: ammo
         amount: 42
+
+- type: entity
+  id: CrateArmorySMGHarmony
+  suffix: Drozd
+  parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
+  name: SMG crate
+  description: Contains two high-powered, automatic rifles with four mags. Requires Armory access to open.
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponSubMachineGunDrozd
+        amount: 2
+      - id: MagazinePistolSubMachineGun
+        amount: 4
+
+- type: entity
+  id: CrateArmoryShotgunHarmony
+  suffic: kammerer
+  parent: [ CrateWeaponSecure, BaseRestrictedContraband ]
+  name: shotgun crate
+  description: For when the enemy absolutely needs to be replaced with lead. Contains two Kammerer Shotguns, and some standard shotgun shells. Requires Armory access to open.
+  components:
+  - type: StorageFill
+    contents:
+      - id: WeaponShotgunKammerer
+        amount: 2
+      - id: BoxLethalshot
+        amount: 4


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Replaces the WT crate in the cargo request computer with the Drozd crate
- Replaces the Enforcer crate in the cargo request computer with the Kammerer crate
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The WTs and Enforcers are always abused, but not by the right people. Buying straight upgrades to already owned guns for so cheap also makes little sense to me. Both are powerful weapons with already existing niches. The WT as the HoS's trusty SMG, and the enforcer as a riot control gun.
## Technical details
<!-- Summary of code changes for easier review. -->
### _Harmony Namescape
Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml -- Adds the new SMG and shotgun crates.

### Upstream Files
Resources/Prototypes/Catalog/Cargo/cargo_armory.yml -- Changes the orders to use the correct crates
Resources/Prototypes/Procedural/salvage_rewards.yml -- Updates the Salvage loot files to use the correct crates

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![SMG](https://github.com/user-attachments/assets/52907a87-8a5f-44f7-bdb5-7af63debc5e4)
![Shotgun](https://github.com/user-attachments/assets/38958a9a-edec-47c7-aa3d-5c0eaf6e8373)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Changed the contents of the SMG and Shotgun crates to be consistent with station-side weaponry.

