### PR TITLE
Remove Loop from Rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -9,7 +9,7 @@
   - Elkridge
   - Fland
   #- Gate
-  - Loop
+  #- Loop # Harmony, removed
   - Marathon
   - Meta
   - Oasis


### PR DESCRIPTION
## About the PR
Removes Loop from rotation.

## Why / Balance
Over time there has been a general dislike of Loop in Harmony's MRP environment and a desire to remove it from rotation. Shifts on it often have increased levels of LRP activity and undesired chaos. I've waited a few months to see if it got significant improvements but it hasn't, and the mapper is no longer in our Discord to receive feedback.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed Loop from rotation.