### PR TITLE
Shotgun ammo bundle

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -15,3 +15,6 @@ uplink-cluster-weh-desc = Scatters 10 lizard plushies in a circle after a short 
 
 uplink-hyposhell-name = Box of hyposhells
 uplink-hyposhell-desc = A box containing four hyposhells, shotgun shells that can hold 7u of any chemical.
+
+uplink-shotgun-ammo-bundle-name = Shotgun ammo bundle
+uplink-shotgun-ammo-bundle-desc = A dufflebag with buckshot, slug and incendiary rounds. Packed into Bulldog drum magazines for easy loading.

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Backpacks/duffelbag.yml
@@ -1,0 +1,15 @@
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateAmmo
+  id: ClothingBackpackDuffelSyndicateShotgunAmmoFilled
+  name: shotgun ammo bundle
+  description: "Reloading! Contains buckshot, slug and incendiary rounds packed into Bulldog drum magazines."
+  components:
+  - type: StorageFill
+    contents:
+      - id: MagazineShotgun
+        amount: 3
+      - id: MagazineShotgunSlug
+        amount: 3
+      - id: MagazineShotgunIncendiary
+        amount: 2

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -10,6 +10,25 @@
   categories:
   - UplinkExplosives
 # Ammo
+- type: listing
+  id: UplinkShotgunAmmoBundleNukie
+  name: uplink-shotgun-ammo-bundle-name
+  description: uplink-shotgun-ammo-bundle-desc
+  productEntity: ClothingBackpackDuffelSyndicateShotgunAmmoFilled
+  cost:
+    Telecrystal: 8
+  categories:
+  - UplinkAmmo
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+        - SurplusBundle
+
 # Chemicals
 # Deception
 - type: listing
@@ -94,3 +113,24 @@
     - Bartender
     - Zookeeper
 
+- type: listing
+  id: UplinkShotgunAmmoBundleJob
+  name: uplink-shotgun-ammo-bundle-name
+  description: uplink-shotgun-ammo-bundle-desc
+  productEntity: ClothingBackpackDuffelSyndicateShotgunAmmoFilled
+  cost:
+    Telecrystal: 8
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 6
+  categories:
+  - UplinkJob
+  conditions:
+  - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+          - SurplusBundle
+  - !type:BuyerJobCondition
+    whitelist:
+    - Bartender
+    - Zookeeper


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Added a shotgun ammo bundle for nuclear operatives, bartender and zookeeper.

## Why / Balance
There's many ammo types you can buy in uplink, but shotgun shells aren't one of them. This change makes shotgun shells available in uplink.

For 8 TC, you get a syndicate duffle bag with 3 pellet, 3 slug and 2 incendiary Bulldog magazines. Bartenders and zookeepers can get a discount down to 6 TC.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![image](https://github.com/user-attachments/assets/ed438bc3-439b-4b81-8e24-c049e7eccda4)
![image](https://github.com/user-attachments/assets/ce5e7c21-c3d3-4946-ac6f-dc08a17564a6)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: shotgun ammo bundle is now available for select customers
