### PR TITLE
Replaces wizards roundstart belt with wizard belt assortment

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/spellbook-catalog.ftl
@@ -1,0 +1,2 @@
+﻿spellbook-belt-name = Wand Assortment
+spellbook-belt-desc = A collection of wands that allow for a wide variety of utility. The collection includes a wand of death, a wand of door creation, a wand of fireball, a wand of polymorph, a wand of resurrection, and a wand of teleportation. Wands do not recharge, so be conservative in use. Comes in a handy belt.

--- a/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
@@ -9,7 +9,7 @@
     shoes: ClothingShoesWizard
     id: WizardPDA
     ears: ClothingHeadsetAltCommand
-    belt: ClothingBeltWand
+    #afbelt: ClothingBeltWand
     # pocket1: TODO: Include wizard teleport scroll
     pocket2: WizardsGrimoire
 

--- a/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
@@ -9,7 +9,7 @@
     shoes: ClothingShoesWizard
     id: WizardPDA
     ears: ClothingHeadsetAltCommand
-    #afbelt: ClothingBeltWand
+    #afbelt: ClothingBeltWand - Harmony Change
     # pocket1: TODO: Include wizard teleport scroll
     pocket2: WizardsGrimoire
 

--- a/Resources/Prototypes/_Harmony/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/spellbook_catalog.yml
@@ -1,0 +1,12 @@
+﻿- type: listing
+  id: SpellbookWandAssortment
+  name: spellbook-belt-name
+  description: spellbook-belt-desc
+  productEntity: ClothingBeltWandFilled
+  cost:
+    WizCoin: 2
+  categories:
+  - SpellbookEquipment
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -10,3 +10,4 @@
     Wizard: 0.04
     KesslerSyndrome: 0.01
     Zombieteors: 0.01
+

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -10,4 +10,3 @@
     Wizard: 0.04
     KesslerSyndrome: 0.01
     Zombieteors: 0.01
-


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Changed wizards belt to be a purchasable item, coming with multiple wands
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In its current state, no real reason to keep this on you when you only would really be able to buy 2 wands, so this helps make a bit more useful
## Technical details
<!-- Summary of code changes for easier review. -->
added Resources/Locale/en-US/_Harmony/store/spellbook-catalog.ftl - Added belt name and description
changed Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml - Commented out the belt

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

![image](https://github.com/user-attachments/assets/0b639639-7a0b-4090-8670-0dd9999da58b)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Removed wizards roundstart wand belt, changing it to a purchable item containing additional wands
