### PR TITLE
Added raid suit to traitor's uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1635,7 +1635,6 @@
       tags:
       - NukeOpsUplink
 
-
 - type: listing
   id: UplinkHardsuitSyndieElite
   name: uplink-hardsuit-syndieelite-name

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1625,25 +1625,14 @@
   description: uplink-syndie-raid-desc
   icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateRaidBundle
-  #Harmony-Summary of changes
-  #Added to the ability to have it on discount, same as Elite Suit
-  #Increase cost to 12 to match higher tier suits
-  #Commented out whitelist to allow traitors to also buy
-  #End of summary
-  #Start of Harmony Change
-  discountCategory: rareDiscounts
-  discountDownTo:
-    Telecrystal: 7
-  cost:
-    Telecrystal: 12
   categories:
   - UplinkWearables
-#  conditions:
-#  - !type:StoreWhitelistCondition
-#    whitelist:
-#      tags:
-#      - NukeOpsUplink
-#Start of Harmony Change
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+
 
 - type: listing
   id: UplinkHardsuitSyndieElite

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1630,6 +1630,7 @@
   #Increase cost to 12 to match higher tier suits
   #Commented out whitelist to allow traitors to also buy
   #End of summary
+  #Start of Harmony Change
   discountCategory: rareDiscounts
   discountDownTo:
     Telecrystal: 7
@@ -1642,6 +1643,7 @@
 #    whitelist:
 #      tags:
 #      - NukeOpsUplink
+#Start of Harmony Change
 
 - type: listing
   id: UplinkHardsuitSyndieElite

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1625,15 +1625,23 @@
   description: uplink-syndie-raid-desc
   icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateRaidBundle
+  #Harmony-Summary of changes
+  #Added to the ability to have it on discount, same as Elite Suit
+  #Increase cost to 12 to match higher tier suits
+  #Commented out whitelist to allow traitors to also buy
+  #End of summary
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 7
   cost:
-    Telecrystal: 8
+    Telecrystal: 12
   categories:
   - UplinkWearables
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
+#  conditions:
+#  - !type:StoreWhitelistCondition
+#    whitelist:
+#      tags:
+#      - NukeOpsUplink
 
 - type: listing
   id: UplinkHardsuitSyndieElite

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1625,6 +1625,8 @@
   description: uplink-syndie-raid-desc
   icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateRaidBundle
+  cost:
+    Telecrystal: 8
   categories:
   - UplinkWearables
   conditions:

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -67,6 +67,26 @@
     Telecrystal: 4
   categories:
   - UplinkWearables
+
+- type: listing
+  id: UplinkClothingOuterArmorRaidHarmony
+  name: uplink-syndie-raid-name
+  description: uplink-syndie-raid-desc
+  icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
+  productEntity: ClothingBackpackDuffelSyndicateRaidBundle
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 7
+  cost:
+    Telecrystal: 12
+  categories:
+  - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+        - NukeOpsUplink
+
 # Pointless
 - type: listing
   id: UplinkClusterWeh


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
After hearing Gray wanting this and talking with someone people about the idea I decided why not try to do this. So I added the raid suit to traitor uplinks.

## Why / Balance
The raid suits were meant for use by Nukies, but because of the lack of space protection basically make it useless to them. It would be far more useful to normal traitors as spacing is less of a issue for them. Additionally as it would be access by normal traitors increased it's cost to 12TC to match the Elite and Jugg suits.

## Technical details
On recommendation of Bosko made a duplicate in _Harmony uplink catalog specifically for traitors, increased the cost to 12TC, and added ability for it to be discounted to 7TC. The normal Nukie one remands unchanged

## Media

https://youtu.be/DljW4h0rQkI



## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Traitors can now buy raid suits at 12TC.


