### PR TITLE
Added rings to loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -64,6 +64,8 @@
   - TowelColorYellow
   - TowelStripedOrange # Harmony
   - PlushieVox
+  - SilverRing
+  - GoldRing
 #deltav specific trinkets
   - TapeRecorder
 
@@ -1138,7 +1140,7 @@
   - DetectiveBlueCoatHarmony # Harmony
   - DetectiveBomberCoatHarmony # Harmony
   - DetectiveDiscoCoatHarmony # Harmony
- 
+
 - type: loadoutGroup
   id: SecurityCadetJumpsuit
   name: loadout-group-security-cadet-jumpsuit

--- a/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
@@ -71,6 +71,18 @@
     back:
     - PlushieVox
 
+- type: loadout
+  id: SilverRing
+  storage:
+    back:
+    - SilverRing
+
+- type: loadout
+  id: GoldRing
+  storage:
+    back:
+    - GoldRing
+
 # Towels
 - type: loadout
   id: TowelStripedOrange


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
We have plenty of IC relationships on Harmony so why not allow them to show off with rings.

## Why / Balance
This is purely for RP purposes.

## Technical details
Add rings into _Harmony to loadouts and to loadout_groups

## Media
![Rings_Loadout](https://github.com/user-attachments/assets/8d686712-207d-4a69-9584-97a1262dddd3)


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added silver and gold rings to loadouts
