### PR TITLE
Allow lathes/fab to eject full 30 stacks

### DIFF
--- a/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class MaterialDisplay : PanelContainer
         if (!_canEject)
             return;
 
-        int[] sheetsToEjectArray = { 1, 5, 10 };
+        int[] sheetsToEjectArray = { 1, 5, 10, 30 }; //Harmony change: Added 30
 
         for (var i = 0; i < sheetsToEjectArray.Length; i++)
         {


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
It's annoying having to spam click 10 stacks to get a full stack, which everyone uses, so instead let's make it one click away.

## Why / Balance
Nice QoL for anyone who needs to remove materials, mostly for cargo.

## Technical details
Simply added 30 to the ui eject array.

## Media
https://youtu.be/TmXRu0ekpHE

![30_Lathe](https://github.com/user-attachments/assets/fcdc87eb-a248-4465-9c05-828c0753a12c)


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Lathes/Fabs can now eject full 30 stacks


