### PR TITLE
Wizard Gamemode Round-End Changes

### DIFF
--- a/Content.Server/_Harmony/GameTicking/Rules/Components/WizardRuleComponent.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/Components/WizardRuleComponent.cs
@@ -36,13 +36,14 @@ public sealed partial class WizardRuleComponent : Component
     public string RoundEndTextAnnouncement = "wizard-no-more-threat-announcement";
 
     /// <summary>
-    /// Time to emergency shuttle to arrive if the wizard dies.
+    /// Time until the emergency shuttle arrives after the wizard dies.
     /// </summary>
     [DataField]
     public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// Delay before triggering a sleeper agent event after the shuttle is recalled
+    /// Holds the delayed server time for when a sleeper agent event should be triggered after the shuttle is recalled.
+    /// Zero when not currently awaiting a time.
     /// </summary>
     [DataField]
     public TimeSpan SleeperTime = TimeSpan.Zero;

--- a/Content.Server/_Harmony/GameTicking/Rules/Components/WizardRuleComponent.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/Components/WizardRuleComponent.cs
@@ -1,0 +1,56 @@
+using Content.Server.GameTicking.Rules;
+using Content.Server.RoundEnd;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Server._Harmony.GameTicking.Rules.Components;
+
+[RegisterComponent, Access(typeof(WizardRuleSystem))]
+public sealed partial class WizardRuleComponent : Component
+{
+    /// <summary>
+    /// What will happen if the wizard dies.
+    /// </summary>
+    [DataField]
+    public RoundEndBehavior RoundEndBehavior = RoundEndBehavior.ShuttleCall;
+
+    /// <summary>
+    /// Text sender for shuttle call if the wizard dies.
+    /// </summary>
+    [DataField]
+    public string RoundEndTextSender = "comms-console-announcement-title-centcom";
+
+    /// <summary>
+    /// Text for shuttle call if the wizard dies.
+    /// </summary>
+    [DataField]
+    public string RoundEndTextShuttleCall = "wizard-no-more-threat-announcement-shuttle-call";
+
+    /// <summary>
+    /// Text for shuttle call if the wizard dies. Used if shuttle is already called.
+    /// </summary>
+    [DataField]
+    public string RoundEndTextAnnouncement = "wizard-no-more-threat-announcement";
+
+    /// <summary>
+    /// Time to emergency shuttle to arrive if the wizard dies.
+    /// </summary>
+    [DataField]
+    public TimeSpan EvacShuttleTime = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Delay before triggering a sleeper agent event after the shuttle is recalled
+    /// </summary>
+    [DataField]
+    public TimeSpan SleeperTime = TimeSpan.Zero;
+
+    /// <summary>
+    /// Becomes true after the wizard dies.
+    /// Determines if the shuttle being recalled should schedule a sleeper agent event to keep round pace going.
+    /// </summary>
+    [DataField]
+    public bool AwaitingPossibleRecall = false;
+}

--- a/Content.Server/_Harmony/GameTicking/Rules/WizardRuleSystem.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/WizardRuleSystem.cs
@@ -1,0 +1,111 @@
+using Content.Server._Harmony.GameTicking.Rules.Components;
+using Content.Shared._Harmony.Wizard;
+using Content.Server.GameTicking.Rules;
+using Content.Shared.Mobs;
+using System.Linq;
+using Content.Shared.Mobs.Components;
+using Content.Server.RoundEnd;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Harmony.GameTicking.Rules;
+
+public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
+{
+    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShuttleRecalledEvent>(_ => OnShuttleRecall());
+        SubscribeLocalEvent<WizardComponent, ComponentRemove>(OnComponentRemove);
+        SubscribeLocalEvent<WizardComponent, MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    private void OnComponentRemove(EntityUid uid, WizardComponent component, ComponentRemove args)
+    {
+        CheckRoundShouldEnd();
+    }
+
+    private void OnMobStateChanged(EntityUid uid, WizardComponent component, MobStateChangedEvent ev)
+    {
+        if (ev.NewMobState == MobState.Dead)
+            CheckRoundShouldEnd();
+    }
+
+    // This is more or less copied from NukeopsRuleSystem. All I know is that it works.
+    private void CheckRoundShouldEnd()
+    {
+        var query = QueryActiveRules();
+        while (query.MoveNext(out _, out _, out var wizard, out _))
+        {
+            CheckRoundShouldEnd(wizard);
+        }
+    }
+
+    private void CheckRoundShouldEnd(WizardRuleComponent wizardRule)
+    {
+        // Only checks if the mob with the wizard component is alive somewhere. Doesn't check where.
+        var wizard = EntityQuery<WizardComponent, MobStateComponent>(true);
+        var wizardAlive = wizard
+            .Any(wiz => wiz.Item2.CurrentState == MobState.Alive && wiz.Item1.Running);
+
+        if (wizardAlive)
+            return;
+
+        _roundEndSystem.DoRoundEndBehavior(wizardRule.RoundEndBehavior,
+            wizardRule.EvacShuttleTime,
+            wizardRule.RoundEndTextSender,
+            wizardRule.RoundEndTextShuttleCall,
+            wizardRule.RoundEndTextAnnouncement);
+
+        // Don't call multiple times
+        wizardRule.RoundEndBehavior = RoundEndBehavior.Nothing;
+        // Set the flag to schedule a sleeper event if the automatic shuttle is recalled to keep the round interesting post-wizard.
+        wizardRule.AwaitingPossibleRecall = true;
+    }
+
+    private void OnShuttleRecall()
+    {
+        var query = QueryActiveRules();
+        while (query.MoveNext(out _, out _, out var wizardRule, out _))
+        {
+            if (wizardRule.AwaitingPossibleRecall == true)
+            {
+                // Schedules a sleeper event in 5 minutes.
+                wizardRule.SleeperTime = _timing.CurTime + TimeSpan.FromMinutes(5);
+                wizardRule.AwaitingPossibleRecall = false;
+            }
+        }
+    }
+
+    private void TryAddSleeper(WizardRuleComponent wizardRule)
+    {
+        // Sleeper agent events are only meant to trigger once per round.
+        // We're going to keep this true for the forced sleeper event, and first check if one has occurred already.
+        if (GameTicker.AllPreviousGameRules.Any(p => p.Item2 == "SleeperAgents"))
+        {
+            Log.Info("Tried to start a sleeper agent event, but one has already occurred");
+            return;
+        }
+
+        GameTicker.AddGameRule("SleeperAgents");
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = QueryActiveRules();
+        while (query.MoveNext(out _, out _, out var wizardRule, out _))
+        {
+            if (wizardRule.SleeperTime != TimeSpan.Zero && _timing.CurTime > wizardRule.SleeperTime)
+            {
+                TryAddSleeper(wizardRule);
+                wizardRule.SleeperTime = TimeSpan.Zero;
+            }
+        }
+    }
+}
+

--- a/Content.Server/_Harmony/GameTicking/Rules/WizardRuleSystem.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/WizardRuleSystem.cs
@@ -84,13 +84,17 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
     {
         // Sleeper agent events are only meant to trigger once per round.
         // We're going to keep this true for the forced sleeper event, and first check if one has occurred already.
+
+        // Note that the event used here is a separate version parented from the normal event, but it will still check if the original
+        // event has happened before as they are functionally identical. The wizard version may be configured later.
+        // If this should stack on top of the normal sleeper event instead of being blocked by it, then the below check can be commented out.
         if (GameTicker.AllPreviousGameRules.Any(p => p.Item2 == "SleeperAgents"))
         {
             Log.Info("Tried to start a sleeper agent event, but one has already occurred");
             return;
         }
 
-        GameTicker.AddGameRule("SleeperAgents");
+        GameTicker.AddGameRule("PostWizardSleeperAgents");
     }
 
     public override void Update(float frameTime)
@@ -108,4 +112,3 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
         }
     }
 }
-

--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared._Harmony.Wizard;   // Harmony addition
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -508,6 +509,23 @@ public abstract class SharedMagicSystem : EntitySystem
 
         ev.Handled = true;
         Speak(ev);
+
+        // Harmony addition begins - Wizards now have a WizardComponent, and this needs to stay on whichever body contains the wizard's mind.
+        // This is so the shuttle can be auto-called if the wizard dies.
+        // This component doesn't control the wizard's antag status or faction or whatever else.
+
+        if (HasComp<WizardComponent>(ev.Performer) && !HasComp<WizardComponent>(ev.Target))
+        {
+            AddComp<WizardComponent>(ev.Target);
+            RemComp<WizardComponent>(ev.Performer);
+        }
+        else if (!HasComp<WizardComponent>(ev.Performer) && HasComp<WizardComponent>(ev.Target))    //How?
+        {
+            AddComp<WizardComponent>(ev.Performer);
+            RemComp<WizardComponent>(ev.Target);
+        }
+
+        // Harmony addition ends
 
         // Need performer mind, but target mind is unnecessary, such as taking over a NPC
         // Need to get target mind before putting performer mind into their body if they have one

--- a/Content.Shared/_Harmony/Wizard/WizardComponent.cs
+++ b/Content.Shared/_Harmony/Wizard/WizardComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Harmony.Wizard;
+
+/// <summary>
+/// This is used for tagging a mob as a wizard.
+/// Component will be transferred on mindswap, so the mob containing the wizard mind will always have the wizard component.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class WizardComponent : Component
+{
+
+}

--- a/Resources/Locale/en-US/_Harmony/wizard/wizard.ftl
+++ b/Resources/Locale/en-US/_Harmony/wizard/wizard.ftl
@@ -1,2 +1,3 @@
 wizard-no-more-threat-announcement-shuttle-call = Based on our scans from our long-range sensors, the magical threat is now eliminated. We will call an emergency shuttle that will arrive shortly. ETA: {$time} {$units}. You can recall the shuttle to extend the shift.
 wizard-no-more-threat-announcement = Based on our scans from our long-range sensors, the magical threat is now eliminated. Shuttle is already called.
+station-event-communication-interception-wizard = Attention! Former magic presence aboard the station has attracted enemy attention. Security level elevated.

--- a/Resources/Locale/en-US/_Harmony/wizard/wizard.ftl
+++ b/Resources/Locale/en-US/_Harmony/wizard/wizard.ftl
@@ -1,0 +1,2 @@
+wizard-no-more-threat-announcement-shuttle-call = Based on our scans from our long-range sensors, the magical threat is now eliminated. We will call an emergency shuttle that will arrive shortly. ETA: {$time} {$units}. You can recall the shuttle to extend the shift.
+wizard-no-more-threat-announcement = Based on our scans from our long-range sensors, the magical threat is now eliminated. Shuttle is already called.

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -256,6 +256,8 @@
     earliestStart: 30
     reoccurrenceDelay: 60
     minimumPlayers: 10
+  - type: WizardRule  # Harmony addition - wizard gamerule specifies round ending text and behavior when the wizard dies.
+    roundEndBehavior: Nothing # Round should not end from wizard dying on a midround wizard spawn.
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:
@@ -274,6 +276,7 @@
         #sound: "/Audio/Ambience/Antag/wizard_start.ogg"
       # TODO: WizardComp as needed
       components:
+      - type: Wizard  # Harmony addition - wizards have a WizardComponent now
       - type: NpcFactionMember
         factions:
         - Wizard

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -271,6 +271,7 @@
   components:
   - type: GameRule
     minPlayers: 10
+  - type: WizardRule # Harmony addition - wizard gamerule specifies round ending text and behavior when the wizard dies.
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn
@@ -289,6 +290,7 @@
       startingGear: WizardBlueGear
       # TODO: WizardComp as needed
       components:
+      - type: Wizard  # Harmony addition - wizards have a WizardComponent now
       - type: NpcFactionMember
         factions:
         - Wizard

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -36,6 +36,8 @@
   parent: BaseWizardRule
   id: SubWizard
   components:
+  - type: WizardRule  # Harmony addition - wizard gamerule specifies round ending text and behavior when the wizard dies.
+    roundEndBehavior: Nothing # Round should not end from wizard dying on wizard subgamemode.
   - type: AntagSelection
     agentName: wizard-round-end-name
     selectionTime: PrePlayerSpawn
@@ -54,6 +56,7 @@
       startingGear: WizardBlueGear
       # TODO: WizardComp as needed
       components:
+      - type: Wizard  # Harmony addition - wizards have a WizardComponent now
       - type: NpcFactionMember
         factions:
         - Wizard

--- a/Resources/Prototypes/_Harmony/GameRules/events.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/events.yml
@@ -1,0 +1,6 @@
+- type: entity
+  parent: SleeperAgents
+  id: PostWizardSleeperAgents
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-communication-interception-wizard


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Wizards now have a wizard component, which follows them even after mindswapping to a different body.

The first major addition is that when the entity with the wizard component dies, is deleted, or has their wizard component removed through debug, an automatic evac shuttle will be called to arrive in 5 minutes time. This is identical to the functionality during nukeops, except that the time until evac is 5 minutes instead of 3, and there is no checks for if the entity is stranded on another map like there is for nukies.

The second major addition is that if the automatic post-wizard shuttle is recalled, a unique sleeper agent event will be scheduled for 5 minutes time, which will trigger as long as a normal sleeper event has not already occurred during this round.
Both of these changes **only affect the main wizard gamemode**, and not the wizard subgamemode or midround spawn.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These changes are meant to combat the main issue with the wizard gamemode, being that the round can quickly become extremely slow and boring if the wizard dies particularly early into the round. Since there are no other major threats to the stations peace (besides maybe some thieves), the round essentially becomes extended gamemode from the moment the wizard dies, which leads to players quickly getting bored.

In the event that a wizard did a lot of damage to the station and successfully became a nukeops-level threat to the crew, then the crew will be given a quicker conclusion for the round after taking them down. However, if the wizard was killed quickly or without significant damage to the crew or station, then they may choose to continue the round by recalling the shuttle. Since there are usually no other threats to the station, the forced sleeper event guarantees some traitors will be introduced into the round, filling the absence of threats and keeping round pace going.

In essence, this is meant to turn the round into traitors lite instead of extended if the crew decide to keep the round going, since knowing the action is over turns the round boring.

## Technical details
<!-- Summary of code changes for easier review. -->
WizardComponent, WizardRuleComponent and WizardRuleSystem added. Wizards always spawn with wizard component and wizard rule component, but RoundEndBehavior in wizard rule component will be set to nothing unless spawned from the wizard gamemode, so its the same as loneops and the corresponding nukeopsrulecomponent.
OnMindswapSpell in upstream file SharedMagicSystem modified to transfer the wizard component.
Harmony namespaced events file added, contains the post-wizard variant of the sleeper agent event PostWizardSleeperAgents which parents from SleeperAgents but with different text.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
**Time between recall and sleeper event changed to 10 seconds for demo purposes, its usually 5 minutes**
https://github.com/user-attachments/assets/795f803d-90d3-4283-b358-c8b6ce15a6fe


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
