### PR TITLE
Removes extended from the pool and adjusts odds to compensate

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,8 +4,8 @@
 # Harmony Changes
     Traitor: 0.66
     Nukeops: 0.15
-    Survival: 0.10
-    Zombie: 0.08
+    Survival: 0.12
+    Zombie: 0.06
     Zombieteors: 0.01
 # Harmony change. Remove Wizard and Kessler from the pool.
 #   Wizard: 0.04
@@ -14,5 +14,5 @@
 # Harmony change: Remove extended from the pool, change odds for survival, zombie and nukeops
 #   Extended: 0.08
 #   Nukeops: 0.13
-#   Zombie: 0.08
+#   Zombie: 0.04
 #   Survival: 0.08

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,11 +3,16 @@
   weights:
 # Harmony Changes
     Traitor: 0.66
-    Nukeops: 0.13
-    Survival: 0.08
-    Extended: 0.08
-    Zombie: 0.04
+    Nukeops: 0.15
+    Survival: 0.10
+    Zombie: 0.08
     Zombieteors: 0.01
 # Harmony change. Remove Wizard and Kessler from the pool.
 #   Wizard: 0.04
 #   KesslerSyndrome: 0.01
+
+# Harmony change: Remove extended from the pool, change odds for survival, zombie and nukeops
+#   Extended: 0.08
+#   Nukeops: 0.13
+#   Zombie: 0.08
+#   Survival: 0.08

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,18 +1,16 @@
 - type: weightedRandom
   id: Secret
   weights:
-# Harmony Changes
+#   Nukeops: 0.20
+#   Traitor: 0.55
+#   Zombie: 0.05
+#   Survival: 0.10
+#   Revolutionary: 0.05
+#   Wizard: 0.05 # Why not, should probably be lower
+
+    # Harmony Changes
     Traitor: 0.66
     Nukeops: 0.15
     Survival: 0.12
     Zombie: 0.06
     Zombieteors: 0.01
-# Harmony change. Remove Wizard and Kessler from the pool.
-#   Wizard: 0.04
-#   KesslerSyndrome: 0.01
-
-# Harmony change: Remove extended from the pool, change odds for survival, zombie and nukeops
-#   Extended: 0.08
-#   Nukeops: 0.13
-#   Zombie: 0.04
-#   Survival: 0.08

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,16 +1,16 @@
 - type: weightedRandom
   id: Secret
   weights:
-#   Nukeops: 0.20
-#   Traitor: 0.55
-#   Zombie: 0.05
-#   Survival: 0.10
-#   Revolutionary: 0.05
-#   Wizard: 0.05 # Why not, should probably be lower
-
-    # Harmony Changes
+    # Start harmony changes
     Traitor: 0.66
-    Nukeops: 0.15
+    Nukeops: 0.13
     Survival: 0.12
-    Zombie: 0.06
+    Zombie: 0.08
     Zombieteors: 0.01
+    # Nukeops: 0.20
+    # Traitor: 0.55
+    # Zombie: 0.05
+    # Survival: 0.10
+    # Revolutionary: 0.05
+    # Wizard: 0.05 # Why not, should probably be lower
+    # End harmony changes


### PR DESCRIPTION
## About the PR
This PR removes Extended from the pool and distributes the odds accordingly:
Traitor: 66% -> 66%
Nukeops: 13% -> 13%
Survival: 8% -> 12%
Zombies: 4% -> 8%
Zombieteors: 1% -> 1%
Extended: 8% -> 0%

## Why / Balance
I will explain my reasoning for the specific changes below. I would like to note that these ARE opinionated, and there can and should be alternative solutions proposed for admin discussion.

Traitors: Seeing as this is supposed to be the "baseline" gamemode, I think messing with these odds upsets the game too much.

Nukeops: After a while of thinking I've decided to turn this into a separate PR down the line if I feel like it. Odds stay the same now.

Zombies: Probably the most controversial one of them all, but honestly, Harmony don't see zombies nearly enough. Now they should still be rare but now atleast attainable.

Survival: I think Survival facilitates roleplay-focused gameplay, similarly to Extended, so it should satisfy those who prefer Extended not be removed.

Extended: I'm not going to discuss the change in-depth here, as there is already plenty of discussion up in other threads. but most of it boils down to making Extended admin-only and making it so players are notified about it before roundstart. I heavily support this sentiment and it is mainly why I decided to remove Extended entirely instead of reducing the odds of it rolling.

## Technical details
Changed the odds around in secret_weights.yml

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
## Breaking changes
**Changelog**
:cl:
- remove: Removed Extended from the natural gamemode pool
- tweak: Adjusted odds of other gamemodes
