### PR TITLE
Removes pipe coloring cooldown from spray painter

### DIFF
--- a/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class SprayPainterComponent : Component
     public TimeSpan AirlockSprayTime = TimeSpan.FromSeconds(3);
 
     [DataField]
-    public TimeSpan PipeSprayTime = TimeSpan.FromSeconds(0); // Harmony Change - Pipe speed go bye bye 1 -> 0
+    public TimeSpan PipeSprayTime = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Pipe color chosen to spray with.

--- a/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class SprayPainterComponent : Component
     public TimeSpan AirlockSprayTime = TimeSpan.FromSeconds(3);
 
     [DataField]
-    public TimeSpan PipeSprayTime = TimeSpan.FromSeconds(1);
+    public TimeSpan PipeSprayTime = TimeSpan.FromSeconds(0); // Harmony Change - Pipe speed go bye bye 1 -> 0
 
     /// <summary>
     /// Pipe color chosen to spray with.

--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -16,6 +16,7 @@
       enum.SprayPainterUiKey.Key:
         type: SprayPainterBoundUserInterface
   - type: SprayPainter
+    pipeSprayTime: 0 # Harmony Change, 1 -> 0
     colorPalette:
       red: '#FF1212FF'
       yellow: '#B3A234FF'


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
turned the time to color pipes from 1 -> 0
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It encourages atmos techs to color their pipes since it no longer takes forever, at the cost of their ears
## Technical details
<!-- Summary of code changes for easier review. -->
Content.Shared/SprayPainter/Components/SprayPainterComponent.cs - 1 to 0
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/86756a5e-1c47-426f-af97-2a27980aafd1


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Spray painters now instantly color pipes
