### PR TITLE
Borg loadout name port

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -55,7 +55,7 @@ public sealed partial class BorgMenu : FancyWindow
             NameIdentifierLabel.Text = nameIdentifierComponent.FullIdentifier;
 
             var fullName = _entity.GetComponent<MetaDataComponent>(Entity).EntityName;
-             // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: prevent exceptions
+             // Harmony Change -- port of Frontier borg name loadouts -- Frontier: prevent exceptions
             if (fullName.Contains(nameIdentifierComponent.FullIdentifier))
                 NameLineEdit.Text = fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1);
             else

--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -55,7 +55,7 @@ public sealed partial class BorgMenu : FancyWindow
             NameIdentifierLabel.Text = nameIdentifierComponent.FullIdentifier;
 
             var fullName = _entity.GetComponent<MetaDataComponent>(Entity).EntityName;
-             // Frontier: prevent exceptions
+             // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: prevent exceptions
             if (fullName.Contains(nameIdentifierComponent.FullIdentifier))
                 NameLineEdit.Text = fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1);
             else

--- a/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
+++ b/Content.Client/Silicons/Borgs/BorgMenu.xaml.cs
@@ -55,8 +55,12 @@ public sealed partial class BorgMenu : FancyWindow
             NameIdentifierLabel.Text = nameIdentifierComponent.FullIdentifier;
 
             var fullName = _entity.GetComponent<MetaDataComponent>(Entity).EntityName;
-            var name = fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1);
-            NameLineEdit.Text = name;
+             // Frontier: prevent exceptions
+            if (fullName.Contains(nameIdentifierComponent.FullIdentifier))
+                NameLineEdit.Text = fullName.Substring(0, fullName.Length - nameIdentifierComponent.FullIdentifier.Length - 1);
+            else
+                NameLineEdit.Text = fullName;
+            // End Frontier
         }
         else
         {

--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -15,10 +15,10 @@ public static class Identity
     /// </summary>
     public static string Name(EntityUid uid, IEntityManager ent, EntityUid? viewer=null)
     {
-        if (!uid.IsValid() || !ent.TryGetComponent(uid, out MetaDataComponent? meta)) // Frontier: add TryGetComponent
+        if (!uid.IsValid() || !ent.TryGetComponent(uid, out MetaDataComponent? meta)) // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: add TryGetComponent
             return string.Empty;
 
-        //var meta = ent.GetComponent<MetaDataComponent>(uid); // Frontier: exception safety
+        //var meta = ent.GetComponent<MetaDataComponent>(uid); // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: exception safety
         if (meta.EntityLifeStage <= EntityLifeStage.Initializing)
             return meta.EntityName; // Identity component and such will not yet have initialized and may throw NREs
 
@@ -28,11 +28,11 @@ public static class Identity
             return uidName;
 
         var ident = identity.IdentityEntitySlot.ContainedEntity;
-        if (ident is null|| !ent.TryGetComponent(ident.Value, out MetaDataComponent? identMeta)) // Frontier: add TryGetComponent
+        if (ident is null|| !ent.TryGetComponent(ident.Value, out MetaDataComponent? identMeta)) // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: add TryGetComponent
             return uidName;
 
-        //var identName = ent.GetComponent<MetaDataComponent>(ident.Value).EntityName; // Frontier: exception safety
-        var identName = identMeta.EntityName; // Frontier: exception safety
+        //var identName = ent.GetComponent<MetaDataComponent>(ident.Value).EntityName; // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: exception safety
+        var identName = identMeta.EntityName; // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: exception safety
         if (viewer == null || !CanSeeThroughIdentity(uid, viewer.Value, ent))
         {
             return identName;

--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -15,10 +15,10 @@ public static class Identity
     /// </summary>
     public static string Name(EntityUid uid, IEntityManager ent, EntityUid? viewer=null)
     {
-        if (!uid.IsValid() || !ent.TryGetComponent(uid, out MetaDataComponent? meta)) // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: add TryGetComponent
+        if (!uid.IsValid() || !ent.TryGetComponent(uid, out MetaDataComponent? meta)) // Harmony Change -- port of Frontier borg name loadouts -- Frontier: add TryGetComponent
             return string.Empty;
 
-        //var meta = ent.GetComponent<MetaDataComponent>(uid); // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: exception safety
+        //var meta = ent.GetComponent<MetaDataComponent>(uid); // Harmony Change -- port of Frontier borg name loadouts -- Frontier: exception safety
         if (meta.EntityLifeStage <= EntityLifeStage.Initializing)
             return meta.EntityName; // Identity component and such will not yet have initialized and may throw NREs
 
@@ -28,11 +28,11 @@ public static class Identity
             return uidName;
 
         var ident = identity.IdentityEntitySlot.ContainedEntity;
-        if (ident is null|| !ent.TryGetComponent(ident.Value, out MetaDataComponent? identMeta)) // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: add TryGetComponent
+        if (ident is null|| !ent.TryGetComponent(ident.Value, out MetaDataComponent? identMeta)) // Harmony Change -- port of Frontier borg name loadouts -- Frontier: add TryGetComponent
             return uidName;
 
-        //var identName = ent.GetComponent<MetaDataComponent>(ident.Value).EntityName; // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: exception safety
-        var identName = identMeta.EntityName; // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: exception safety
+        //var identName = ent.GetComponent<MetaDataComponent>(ident.Value).EntityName; // Harmony Change -- port of Frontier borg name loadouts -- Frontier: exception safety
+        var identName = identMeta.EntityName; // Harmony Change -- port of Frontier borg name loadouts -- Frontier: exception safety
         if (viewer == null || !CanSeeThroughIdentity(uid, viewer.Value, ent))
         {
             return identName;

--- a/Content.Shared/IdentityManagement/Identity.cs
+++ b/Content.Shared/IdentityManagement/Identity.cs
@@ -15,10 +15,10 @@ public static class Identity
     /// </summary>
     public static string Name(EntityUid uid, IEntityManager ent, EntityUid? viewer=null)
     {
-        if (!uid.IsValid())
+        if (!uid.IsValid() || !ent.TryGetComponent(uid, out MetaDataComponent? meta)) // Frontier: add TryGetComponent
             return string.Empty;
 
-        var meta = ent.GetComponent<MetaDataComponent>(uid);
+        //var meta = ent.GetComponent<MetaDataComponent>(uid); // Frontier: exception safety
         if (meta.EntityLifeStage <= EntityLifeStage.Initializing)
             return meta.EntityName; // Identity component and such will not yet have initialized and may throw NREs
 
@@ -28,10 +28,11 @@ public static class Identity
             return uidName;
 
         var ident = identity.IdentityEntitySlot.ContainedEntity;
-        if (ident is null)
+        if (ident is null|| !ent.TryGetComponent(ident.Value, out MetaDataComponent? identMeta)) // Frontier: add TryGetComponent
             return uidName;
 
-        var identName = ent.GetComponent<MetaDataComponent>(ident.Value).EntityName;
+        //var identName = ent.GetComponent<MetaDataComponent>(ident.Value).EntityName; // Frontier: exception safety
+        var identName = identMeta.EntityName; // Frontier: exception safety
         if (viewer == null || !CanSeeThroughIdentity(uid, viewer.Value, ent))
         {
             return identName;

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -79,7 +79,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
             name = Loc.GetString(_random.Pick(nameData.Values));
         }
 
-        // Frontier: apply name modifiers
+        // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: apply name modifiers
 
 
 

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Inventory;
 using Content.Shared.Item;
+using Content.Shared.NameIdentifier;
 using Content.Shared.Preferences.Loadouts;
 using Content.Shared.Roles;
 using Content.Shared.Storage;
@@ -77,6 +78,27 @@ public abstract class SharedStationSpawningSystem : EntitySystem
         {
             name = Loc.GetString(_random.Pick(nameData.Values));
         }
+
+        // Frontier: apply name modifiers
+
+
+
+        if (TryComp<NameIdentifierComponent>(entity, out var nameIdentifier))
+
+
+        {
+
+
+            // Append our name identifier (why have a pseudonym for a role that has a complete name identifier group?)
+
+
+            name = $"{name} {nameIdentifier.FullIdentifier}";
+
+
+        }
+
+
+        // End Frontier
 
         if (!string.IsNullOrEmpty(name))
         {

--- a/Content.Shared/Station/SharedStationSpawningSystem.cs
+++ b/Content.Shared/Station/SharedStationSpawningSystem.cs
@@ -79,7 +79,7 @@ public abstract class SharedStationSpawningSystem : EntitySystem
             name = Loc.GetString(_random.Pick(nameData.Values));
         }
 
-        // Harmony Chage -- port of Frontier borg name loadouts -- Frontier: apply name modifiers
+        // Harmony Change -- port of Frontier borg name loadouts -- Frontier: apply name modifiers
 
 
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ See [LICENSE-MIT.TXT](LICENSE-MIT.txt).
 Most assets are licensed under [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) unless stated otherwise. Assets have their license and the copyright in the metadata file. [Example](https://github.com/ss14-harmony/ss14-harmony/blob/master/Resources/Textures/_Harmony/Clothing/Uniforms/Jumpsuit/hop_turtle.rsi/meta.json).
 
 Note that some assets are licensed under the non-commercial [CC-BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) or similar non-commercial licenses and will need to be removed if you wish to use this project commercially.
+
+
+commit test, please ignore

--- a/README.md
+++ b/README.md
@@ -36,6 +36,3 @@ See [LICENSE-MIT.TXT](LICENSE-MIT.txt).
 Most assets are licensed under [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) unless stated otherwise. Assets have their license and the copyright in the metadata file. [Example](https://github.com/ss14-harmony/ss14-harmony/blob/master/Resources/Textures/_Harmony/Clothing/Uniforms/Jumpsuit/hop_turtle.rsi/meta.json).
 
 Note that some assets are licensed under the non-commercial [CC-BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) or similar non-commercial licenses and will need to be removed if you wish to use this project commercially.
-
-
-commit test, please ignore

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -27,10 +27,11 @@
   - GroupSpeciesBreathTool
 
 # Silicons
-#- type: roleLoadout
-#  id: JobBorg
-#  nameDataset: roleloadout doesn't support both so need to update that first.
-#  canCustomizeName: true
+- type: roleLoadout
+  id: JobBorg
+  nameDataset: NamesBorg
+  canCustomizeName: true
+# Harmony Change - Uncommented above text to enable Custom Borg Names on Loadout
 
 - type: roleLoadout
   id: JobStationAi


### PR DESCRIPTION
## About the PR
Ported Borg Loadout Naming from Frontier

## Why / Balance
Adding the ability for a borg to have a consistent name at round-start allows people to make a borg Character, which is better for RP. This was a hugely beneficial addition for the AI too.

We already have some people who have a Borg Character in Harmony who would benefit from this as well.

Also, not having to ask Science to name you at round-start means that on shifts where science is thin, non-existent, or blantantly disinterested in Robotics, Borgs can still have their own unique names.

Additionally, this might dissuade people from picking a Borg job role for perceived anonimity - by giving support for borgs to be characters, this might give people a sense of accountability for their actions.

## Technical details
Ported Frontier changes from commit https://github.com/new-frontiers-14/frontier-station-14/commit/12857e0e217ca9f17816f27ffd79d11937204e41 and onwards. These commits are under Frontiers AGPL licence.

I ran through and round-started on a Borg with a custom name, and by leaving the field blank. Then, I checked that Borg Names could still be changed by a scientist if needed (such as if a borg goes SSD and has their brain wiped), and everything seems to be working as best as I can tell.

Also also, it seems my test commits to make sure my local DevEnv was able to push to github snuck in. Uh oh. It doesn't actually affect any files and I don't know how to get rid of that.

## Media
![Screenshot 2025-04-03 225416](https://github.com/user-attachments/assets/d6e9ed23-c7f2-47e6-ba37-96ab1b927325)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Borgs can now set a name in their loadout.


