### PR TITLE
Add New Lobby Track "Dropzone"

### DIFF
--- a/Resources/Audio/_Harmony/Lobby/attributions.yml
+++ b/Resources/Audio/_Harmony/Lobby/attributions.yml
@@ -7,3 +7,8 @@
   license: "CC-BY-NC-SA-3.0"
   copyright: "meatballwalkin"
   source: "https://github.com/ss14-harmony/ss14-harmony"
+
+- files: ["dropzone.ogg"]
+  license: "CC-BY-SA 4.0"
+  copyright: "Made by Qwesta"
+  source: "https://discord.com/channels/1168210010233376858/1168217282988757116/1311095405647495401"

--- a/Resources/Audio/_Harmony/Lobby/attributions.yml
+++ b/Resources/Audio/_Harmony/Lobby/attributions.yml
@@ -9,6 +9,6 @@
   source: "https://github.com/ss14-harmony/ss14-harmony"
 
 - files: ["dropzone.ogg"]
-  license: "CC-BY-SA 4.0"
+  license: "CC-BY-SA-4.0"
   copyright: "Made by Qwesta"
   source: "https://discord.com/channels/1168210010233376858/1168217282988757116/1311095405647495401"

--- a/Resources/Prototypes/SoundCollections/lobby.yml
+++ b/Resources/Prototypes/SoundCollections/lobby.yml
@@ -19,3 +19,4 @@
 #Harmony additions
     - /Audio/_Harmony/Lobby/rustycansbattle.ogg
     - /Audio/_Harmony/Lobby/harmonilla.ogg
+    - /Audio/_Harmony/Lobby/dropzone.ogg


### PR DESCRIPTION
<!-- What did you change? -->
Adds new lobby track "Dropzone," by Qwesta. Originally created for RMC and included in PR https://github.com/RMC-14/RMC-14/pull/6021

## Why / Balance
As soon as I heard this I wanted it in Harmony. It works beautifully for RMC but also has that Nukie feel and should be another step towards slowly shifting to unique lobby music.

## Media
[Link](https://discord.com/channels/1168210010233376858/1168217282988757116/1311095405647495401) to the song in the RMC discord.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: New lobby song Dropzone by Qwesta.