### PR TITLE
Make cluwnes revivable

### DIFF
--- a/Content.Server/Cluwne/CluwneSystem.cs
+++ b/Content.Server/Cluwne/CluwneSystem.cs
@@ -53,7 +53,7 @@ public sealed class CluwneSystem : EntitySystem
             RemComp<CluwneComponent>(uid);
             RemComp<ClumsyComponent>(uid);
             RemComp<AutoEmoteComponent>(uid);
-            var damageSpec = new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Genetic"), 300);
+            var damageSpec = new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Genetic"), 100);
             _damageableSystem.TryChangeDamage(uid, damageSpec);
         }
     }

--- a/Content.Server/Cluwne/CluwneSystem.cs
+++ b/Content.Server/Cluwne/CluwneSystem.cs
@@ -53,7 +53,7 @@ public sealed class CluwneSystem : EntitySystem
             RemComp<CluwneComponent>(uid);
             RemComp<ClumsyComponent>(uid);
             RemComp<AutoEmoteComponent>(uid);
-            var damageSpec = new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Genetic"), 100);
+            var damageSpec = new DamageSpecifier(_prototypeManager.Index<DamageGroupPrototype>("Genetic"), 100); /// Harmony Change: From 300 down to 100
             _damageableSystem.TryChangeDamage(uid, damageSpec);
         }
     }


### PR DESCRIPTION
## About the PR
This PR makes a simple change to make cluwnes revivable as per discussions. The request was made after a round where 5 or more people were rendered completely round removed after being made into cluwnes, which does not line up with other transmutation spells like carp and bread. 

## Why / Balance
It was discussed ingame and in the Discord that cluwnes having 300 genetic is extremely undesirable and should be changed. This fact was agreed upon by the community and admins that this change needs to happen.

## Technical details
This affects both the cluwne spell for wizards and the admin smite

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Being cluwned is no longer round removal