### PR TITLE
Adds "Survive" Objective to traitors, makes "Escape to centcomm alive and unrestrained" more rare.

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -33,8 +33,9 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupState
   weights:
-    EscapeShuttleObjective: 1
+    EscapeShuttleObjective: 0.5 #Harmony change
     DieObjective: 0.05
+    TraitorSurviveObjective: 1 #Harmony objective
     #HijackShuttleObjective: 0.02
 
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -33,7 +33,7 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupState
   weights:
-    EscapeShuttleObjective: 0.4 #Harmony change
+    EscapeShuttleObjective: 0.4 #Harmony change: 1 -> 0.4
     DieObjective: 0.05
     TraitorSurviveObjective: 0.6 #Harmony objective
     #HijackShuttleObjective: 0.02

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -33,9 +33,9 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupState
   weights:
-    EscapeShuttleObjective: 0.5 #Harmony change
+    EscapeShuttleObjective: 0.4 #Harmony change
     DieObjective: 0.05
-    TraitorSurviveObjective: 1 #Harmony objective
+    TraitorSurviveObjective: 0.6 #Harmony objective
     #HijackShuttleObjective: 0.02
 
 - type: weightedRandom

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -45,6 +45,13 @@
     icon:
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
+#begin harmony change
+  - type: ObjectiveBlacklistRequirement
+    blacklist:
+      components:
+      - DieCondition
+      - SurviveCondition
+#end harmony change
   - type: EscapeShuttleCondition
 
 - type: entity
@@ -63,6 +70,7 @@
       components:
       - EscapeShuttleCondition
       - StealCondition
+      - SurviveCondition #Harmony change
   - type: DieCondition
 
 #- type: entity

--- a/Resources/Prototypes/_Harmony/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/traitor.yml
@@ -7,8 +7,8 @@
   - type: Objective
     difficulty: 1.3
     icon:
-      sprite: Structures/Furniture/chairs.rsi
-      state: shuttle
+      sprite: Objects/Specific/Medical/medical.rsi
+      state: gauze
   - type: ObjectiveBlacklistRequirement
     blacklist:
       components:

--- a/Resources/Prototypes/_Harmony/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/traitor.yml
@@ -1,0 +1,17 @@
+- type: entity
+  parent: BaseTraitorObjective
+  id: TraitorSurviveObjective
+  name: Survive.
+  description: We just need you alive, cuffs or not. Escaping to centcomm is not necessary.
+  components:
+  - type: Objective
+    difficulty: 1.3
+    icon:
+      sprite: Structures/Furniture/chairs.rsi
+      state: shuttle
+  - type: ObjectiveBlacklistRequirement
+    blacklist:
+      components:
+      - EscapeShuttleCondition
+      - DieCondition
+  - type: SurviveCondition


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
See title, "survive" is at the same difficulty/rarity as current "Escape" is (1.3 difficulty, 0.6 weight) while "Escape" has been changed to be less common (difficulty stays at 1.3, weight is now 0.4, instead of 1)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Community sentiment is that this would overall be a good change, as seen by the poll below. Personally, I think this objective overly discourages traitors to have any mid-round conflict with security, causing issues such as traitors waiting to do their objectives extremely close to evac, giving security nothing to do for the majority of a traitors shift. (also, as far as I'm aware antag activity on the evac shuttle is something that should be discouraged)
![image](https://github.com/user-attachments/assets/ce1fd1e5-4046-4388-ab43-63f995e5d65b)


## Technical details
<!-- Summary of code changes for easier review. -->
Adds:
Resources/Prototypes/_Harmony/Objectives/traitor.yml
Changes:
Resources/Prototypes/Objectives/objectiveGroups.yml
Resources/Prototypes/Objectives/traitor.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/748ed56a-9e1a-4faf-b640-cdc7ef83486a)
## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added a new "Survive" objective for traitors, this objective does not require traitors to board the evac shuttle or be unrestrained.
- tweak: The "Escape to centcomm alive and unrestrained" objective for traitors is now more rare.