### PR TITLE
Adds Roundstart QM Gear - A hardsuit and a unique PKA

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -19,6 +19,8 @@
     - id: RubberStampQm
     - id: AstroNavCartridge
     - id: MailTeleporterMachineCircuitboard
+    - id: ClothingOuterHardsuitQM # Harmony Change, adds a hardsuit for QM
+    - id: WeaponQMKineticSidearm # Harmony Change, adds a unique PKA for QM
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1,0 +1,17 @@
+#Quartermasters Hardsuit
+- type: entity
+  parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
+  id: ClothingHeadHelmetHardsuitQM
+  name: quartermasters hardsuit helmet
+  description: A salvaged pirate helmet generously donated to NanoTrasen, retrofitted for the Quartermaster.
+  components:
+  - type: Sprite
+    sprite: Clothing/Head/Hardsuits/luxury.rsi
+  - type: Clothing
+    sprite: Clothing/Head/Hardsuits/luxury.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.525
+    lowPressureMultiplier: 1000
+  - type: PointLight
+    radius: 7
+    energy: 3

--- a/Resources/Prototypes/_Harmony/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,0 +1,31 @@
+#Quartermaster's Hardsuit
+- type: entity
+  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  id: ClothingOuterHardsuitQM
+  name: quartermasters hardsuit
+  description: A salvaged pirate hardsuit generously donated to NanoTrasen, retrofitted for the Quartermaster.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Hardsuits/luxury.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Hardsuits/luxury.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.5
+  - type: Armor
+    modifiers:
+      coefficients: #Meant to be the average of the salv roundstart and the goliath suit, as it isn't upgradeable.
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.6
+        Heat: 0.9
+        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
+        Caustic: 0.75
+  - type: ClothingSpeedModifier
+    walkModifier: 0.85
+    sprintModifier: 0.9
+  - type: HeldSpeedModifier
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHelmetHardsuitQM

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/kinetic_pistol.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/kinetic_pistol.yml
@@ -1,0 +1,59 @@
+#gun base
+- type: entity
+  name: BaseWeaponKineticSidearm
+  parent: BaseItem
+  id: BaseWeaponKineticSidearm
+  description: A rooty tooty point and shooty, now kinetic.
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
+    state: icon
+  - type: Item
+    size: Small
+    shape:
+    - 0,0,1,0
+    - 0,1,0,1
+  - type: Tag
+    tags:
+    - Sidearm
+  - type: Clothing
+    sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi
+    quickEquip: false
+    slots:
+    - suitStorage
+    - Belt
+  - type: Gun
+    fireRate: 0.75
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
+  - type: AmmoCounter
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.AmmoVisuals.HasAmmo:
+        empty-icon:
+          True: { visible: False }
+          False: { visible: True }
+        #todo: add other 'empty' animations
+  - type: RechargeBasicEntityAmmo
+    rechargeCooldown: 5 # should be recharging after all three shots are done and no sooner.
+    rechargeSound:
+      path: /Audio/Weapons/Guns/MagIn/kinetic_reload.ogg
+  - type: BasicEntityAmmoProvider
+    proto: BulletKinetic
+    capacity: 3
+    count: 3
+  - type: UseDelay
+    delay: 1
+
+
+#gun
+- type: entity
+  name: Quartermaster's Kinetic Revolver
+  parent: [BaseWeaponKineticSidearm, BaseCommandContraband]
+  id: WeaponQMKineticSidearm
+  description: The Quartermaster's retrofitted Pirate Revolver that fires low-damage kinetic bolts at a short range.


### PR DESCRIPTION
## About the PR
Adds two new items, the Quartermaster's Hardsuit and the Quartermaster's Kinetic Revolver.
Also adds them to the locker at round-start.

## Why / Balance
The Quartermaster is one of two Command Members that doesn't get a hardsuit, despite the fact they oversee one of the two departments on station that are expected to go into space, the amount cargo gets spaced, and they are in charge of  a job that dies in space A Lot.

Upstream gave them the Luxury Mining Hardsuit, a hardsuit worse than the basic salv Spationaut Suit that costs 15k spesos to buy. By all accounts, this is a joke item.

The new QM Hardsuit has resistances that are inbetween the Spationaut Suit and the Mining Hardsuit, with the Luxury Hardsuit's low move-speed penalty. This is to make it a viable suit for the QM to use in case of emergencies, without incentivizing Salv to steal it over getting Goliath Suits.

This also adds the Quartermaster's Kinetic Revolver, a PKA with three shots that doesn't need wielding, but with a long time to reload shots. The Kinetic Revolver is inspired by the map _Barratry_ giving the QM a Pirate Revolver.

The Kinetic Revolver cannot down someone in a single volley, it does 75 blunt without armor and with all shots landing. It takes 5 seconds for each bullet to reload. In terms of balance, this can be used by QMs to dissuade unarmored attackers, but cannot kill. The Kinetic Revolver can break open a secure crate in one volley - a tactic commonly used by QMs during WarOps and similar high-threat scenarios. The Kinetic Revolver is useless against any Nukies playing well, a full volley does 30 blunt to a blood-red, and then requires ~12-15 seconds for another volley, by which time the Nukie Agent should have healed them.

The Kinetic Revolver can deal with Space Carp in two shots.

Both of these items combined allow the Quartermaster more interaction with the Salvage side of Supply. By giving them an armored hardsuit and improved PKA, they can realistically mount a recovery mission if all their Salvs die on the VGRoid. Also, it allows the QM to do minor salvaging on lowpop scenarios, and allows the QM better tools to teach new salvagers with.

Both new items are marked as Command Contraband, and so shouldn't be handed to crew.
Hopefully, they provide something for the QM to own that is more impactful to lose than the Digiboard.

On top of that, they are neat. The Unique PKA feels thematic to the QM, and the new hardsuit feels appropriate considering that the CMO and RD get hardsuits as well.

## Technical details
Added four entities: BaseWeaponKineticSidearm, WeaponQMKineticSidearm, ClothingOuterHardsuitQM, ClothingHeadHelmetHardsuitQM.
All four entities are in an appropriate _Harmony folder.

Adds WeaponQMKineticSidearm & ClothingOuterHardsuitQM to the QM's locker list.

Reuses the sprites of the Luxury Mining Hardsuit and Pirate Revolver for the new items, pending custom spriting.
(Custom spriting pending conceptual approval, don't want to waste someones time if the whole concept is deemed uneccessary for Harmony)

## Media
Media incoming.

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
As far as I am aware, no changes here should be breaking.

**Changelog**
:cl:
- add: The QM now starts with a unique hardsuit and PKA

(Drafting this for now, still need sprites & media, but want feedback on the balance & concept)