### PR TITLE
Removes Cargo Access from Salvagers and Alters Doors in Response

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -124,10 +124,16 @@
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsCargo
-  suffix: Cargo, Locked
+# Start of Harmony Change: Updates cargo door electronics suffix
+#  suffix: Cargo, Locked
+  suffix: Cargo, Salvage, Locked
+# End of Harmony Change
   components:
   - type: AccessReader
-    access: [["Cargo"]]
+# Start of Harmony Change: Adds Salvage Access to the Cargo Door Electronic
+#    access: [["Cargo"]]
+    access: [["Cargo"],["Salvage"]]
+# End of Harmony Change
 
 # Engineering
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -505,7 +505,10 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsCargo ]
+# Start of Harmony Change: Locks the ATS to only cargo access
+#      board: [ DoorElectronicsCargo ]
+      board: [ DoorElectronicsCargoHarmony ]
+# End of Harmony Change
   - type: Wires
     layoutId: AirlockCargo
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -68,7 +68,10 @@
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsCargo ]
+# Start of Harmony Change: Locks the cargo shuttle to only cargo access
+#      board: [ DoorElectronicsCargo ]
+      board: [ DoorElectronicsCargoHarmony ]
+# End of Harmony Change
   - type: Wires
     layoutId: AirlockCargo
 

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -13,7 +13,7 @@
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm
   access:
-  - Cargo
+#  - Cargo Harmony Change: Removes Cargo Access from Salvagers
   - Salvage
   - Maintenance
   - External

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/Electronics/door_access.yml
@@ -1,0 +1,9 @@
+# Cargo
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsCargoHarmony
+  suffix: Cargo, Locked, Harmony
+  components:
+  - type: AccessReader
+    access: [["Cargo"]]


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Removes Cargo Access from Salvage Specialists
- Gives Normal Cargo Airlocks Salvage Access
- Updates Cargo Airlocks and windoors to only have cargo access
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Salvagers are just cargo technicians+. This change is to promote inner-departmental communication between salvagers and the rest of their department.
This PR makes cargo doors require either cargo or salvage access. Salvagers still have access to the whole station-side department, but not the buy console, cargo shuttle, or ATS.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed Cargo Access from Salvage Specialists
- tweak: Gives Normal Cargo Airlocks Salvage Access
- tweak: Updated Cargo Airlocks and windoors to only have cargo access

