### PR TITLE
Adds Mini Jetpacks to the Slavage Specialist Lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -17,7 +17,10 @@
     - id: RadioHandheld
     - id: SeismicCharge # Harmony change
     - id: AppraisalTool
-    - id: FireExtinguisher
+# Start of Harmony Change: Replaces the Fire Extinguisher with a minijetpack
+#    - id: FireExtinguisher
+    - id: JetpackMiniFilled
+# End of Harmony Change
     - id: Flare
       prob: 0.3
       rolls: !type:ConstantNumberSelector


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Adds the minijetpack to the Salvage Specialist Locker
- Removes the fire extinguisher from the Salvage Specialist Locker
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In the end, Salvage is just going to steal the ones from EVA by either breaking in, bothering the AI, or just waltzing in and grabbing them. They might as well just start with them so the EVA jetpacks are used in actual emergencies
## Technical details
<!-- Summary of code changes for easier review. -->
### Upstream Files
Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml -- Removes the fire extinguisher and replaces it with minijetpacks

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Mini Jetpacks to Salvage Lockers
- remove: Removed Fire Extinguishers from Salvage Lockers
