### PR TITLE
adds suit storage to all "outerclothing" items

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: Clothing
+  parent: [Clothing, AllowSuitStorageClothing] # Harmony Change - allows suit storage for all clothing
   id: ClothingOuterBase
   components:
   - type: Clothing


### PR DESCRIPTION
## About the PR
allows guns and tanks to be put on non specific "outer clothing" items

## Why / Balance
suit slots being only for select items was a jank way of stopping tiders from stealing o2 cans and among other stuff in a lrp environment, and since this is a mrp server with higher standards this allows coats and other non armored items to be able to have some function, especially for vox players and other future races who need internals on.

## Technical details
the base outer clothing entity now has the allow suit storage entity as their parent

## Media
![image](https://github.com/user-attachments/assets/92209d3a-8dd0-474b-94c0-5fd866a0e78d)
![image](https://github.com/user-attachments/assets/48ef7214-7856-42d8-a517-f5c5218cbc02)
![image](https://github.com/user-attachments/assets/da9bb579-a40e-420a-9cf3-72a40a578e96)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added suit storage capabilities to all outer clothing items!
