### PR TITLE
Harmony traits clone properly (#445)

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Actions;
 using Content.Server.Chat.Systems;
 using Content.Server.Speech.Components;
 using Content.Shared.Chat.Prototypes;
+using Content.Shared.Cloning.Events;
 using Content.Shared.Humanoid;
 using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
@@ -29,6 +30,7 @@ public sealed class VocalSystem : EntitySystem
         SubscribeLocalEvent<VocalComponent, SexChangedEvent>(OnSexChanged);
         SubscribeLocalEvent<VocalComponent, EmoteEvent>(OnEmote);
         SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
+        SubscribeLocalEvent<VocalComponent, CloningEvent>(OnCloning);
     }
 
     private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
@@ -98,5 +100,13 @@ public sealed class VocalSystem : EntitySystem
         if (!component.Sounds.TryGetValue(sex.Value, out var protoId))
             return;
         _proto.TryIndex(protoId, out component.EmoteSounds);
+    }
+
+    // Harmony addition, so that the VoiceOfX traits copy over to clones
+    private void OnCloning(Entity<VocalComponent> ent, ref CloningEvent args)
+    {
+        var cloneVocalComponent = EnsureComp<VocalComponent>(args.CloneUid);
+        cloneVocalComponent.EmoteSounds = ent.Comp.EmoteSounds;
+        cloneVocalComponent.Sounds = ent.Comp.Sounds;
     }
 }

--- a/Content.Shared/Speech/SpeechSystem.cs
+++ b/Content.Shared/Speech/SpeechSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Cloning.Events;
+
 namespace Content.Shared.Speech
 {
     public sealed class SpeechSystem : EntitySystem
@@ -7,6 +9,7 @@ namespace Content.Shared.Speech
             base.Initialize();
 
             SubscribeLocalEvent<SpeakAttemptEvent>(OnSpeakAttempt);
+            SubscribeLocalEvent<SpeechComponent, CloningEvent>(OnCloning);
         }
 
         public void SetSpeech(EntityUid uid, bool value, SpeechComponent? component = null)
@@ -28,6 +31,15 @@ namespace Content.Shared.Speech
         {
             if (!TryComp(args.Uid, out SpeechComponent? speech) || !speech.Enabled)
                 args.Cancel();
+        }
+
+        // Harmony addition, so that the RaisedByX and VoiceOfX traits copy over to clones
+        private void OnCloning(Entity<SpeechComponent> ent, ref CloningEvent args)
+        {
+            var cloneSpeechComponent = EnsureComp<SpeechComponent>(args.CloneUid);
+            cloneSpeechComponent.SpeechSounds = ent.Comp.SpeechSounds;
+            cloneSpeechComponent.SpeechVerb = ent.Comp.SpeechVerb;
+            cloneSpeechComponent.AllowedEmotes = ent.Comp.AllowedEmotes;
         }
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -57,6 +57,9 @@
   - SouthernAccent
   - SpanishAccent
   - StutteringAccent
+  # Harmony specific
+  - Hypophonia
+  - IlleismAccent
   blacklist:
     components:
     - AttachedClothing # helmets, which are part of the suit


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Harmony specific traits (Illeism, Hypophonia, Raised by X, Voice of X) now are cloned properly (e.g. cloning pod or paradox clone).

This is my first harmony PR and my first SS14 related PR to include C# so please let me know if anything needs changing!

## Why / Balance
Closes #445 
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added `IlleismAccent` and `Hypophonia` to the component cloning whitelist in `Resources/Prototypes/Entities/Mobs/Player/clone.yml`.

SpeechSystem and VocalSystem now listen for the CloningEvent at which they will copy over the follow fields to the new clone's component:
SpeechComponent:
- SpeechSounds
- SpeechVerb
- AllowedEmotes
VocalComponent:
- EmoteSounds
- Sounds

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Harmony specific traits are now properly cloned.