### PR TITLE
Increases uplink TC amount and Removes round-start Blood-Reds from Nuclear Operatives

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -94,11 +94,17 @@
 - type: entity
   parent: BaseUplinkRadio
   id: BaseUplinkRadio40TC
-  suffix: 40 TC, NukeOps
+# Start of Harmony Change: Updates suffix to represent proper TC amount
+#  suffix: 40 TC, NukeOps
+  suffix: 45 TC, NukeOps
+# End of Harmony Change
   components:
   - type: Store
     balance:
-      Telecrystal: 40
+# Start of Harmony Change: Adds five TC to the nukie uplink
+#      Telecrystal: 40
+      Telecrystal: 45
+# End of Harmony Change
   - type: Tag
     tags:
     - NukeOpsUplink
@@ -106,11 +112,17 @@
 - type: entity
   parent: BaseUplinkRadio
   id: BaseUplinkRadio60TC
-  suffix: 60 TC, LoneOps
+# Start of Harmony Change: Updates suffix to represent proper TC amount
+#  suffix: 60 TC, LoneOps
+  suffix: 65 TC, LoneOps
+# End of Harmony Change
   components:
   - type: Store
     balance:
-      Telecrystal: 60
+# Start of Harmony Change: Adds five TC to the lone op uplink
+#      Telecrystal: 60
+      Telecrystal: 65
+# End of Harmony Change
   - type: Tag
     tags:
     - NukeOpsUplink

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -47,7 +47,7 @@
     eyes: ClothingEyesHudSyndicate
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterHardsuitSyndie
+#    outerClothing: ClothingOuterHardsuitSyndie Harmony Change: Makes nuclear operatives no longer start with the blood-red hardsuit
     shoes: ClothingShoesBootsCombatFilled
     id: SyndiPDA
     pocket2: PlushieCarp


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Removes the starting blood-red from nuclear operatives and lone op
- Increases the nukie and lone op uplink by 5 TC
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change encourages Nuclear Operatives (Just the operatives, not agent or commander) to try different armor types instead of just the blood-red they start with. This is balanced by giving everyone 5 more TC (Totaling at 20 across the team), so the 16 that has to be spent for a normal blood-red is canceled out.
## Technical details
<!-- Summary of code changes for easier review. -->
### Upstream Files
Resources/Prototypes/Entities/Objects/Specific/syndicate.yml -- Updates Nukie Uplink Amounts
Resources/Prototypes/Roles/Antags/nukeops.yml -- Comments out round-start Blood-Reds from Nuclear Operatives

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: All Nuclear Operative Uplinks Get an Extra 5 TC
- tweak: Nuclear Operatives and Lone Ops No Longer Start with Blood-Reds
