### PR TITLE
Bureaucratic Error event rework

### DIFF
--- a/Content.Server/StationEvents/Components/BureaucraticErrorRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/BureaucraticErrorRuleComponent.cs
@@ -12,4 +12,18 @@ public sealed partial class BureaucraticErrorRuleComponent : Component
     /// </summary>
     [DataField]
     public List<ProtoId<JobPrototype>> IgnoredJobs = new();
+
+    // Start of Harmony change of Bureaucratic Error event
+    /// <summary>
+    /// The minimum number of jobs that can be set to unlimited slots.
+    /// </summary>
+    [DataField]
+    public int MinimumJobs = 1;
+
+    /// <summary>
+    /// The maximum number of jobs that can be set to unlimited slots.
+    /// </summary>
+    [DataField]
+    public int MaximumJobs = 4;
+    // End of Harmony change of Bureaucratic Error event
 }

--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -29,6 +29,21 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
         if (jobList.Count == 0)
             return;
 
+        // Start of Harmony change of Bureaucratic Error event
+        // - Changed for the sake of people generally not liking when the job they want to play loses all slots within 10 minutes.
+        // - Removed the ability for this event to reduce slots from a job, and replaced with picking a random number of jobs to set to unlimited
+        var num = RobustRandom.Next(component.MinimumJobs, component.MaximumJobs); // Get the number of jobs to become unlimited
+
+        for (var i = 0; i < num; i++)
+        {
+            var chosenJob = RobustRandom.PickAndTake(jobList);
+            if (_stationJobs.IsJobUnlimited(chosenStation.Value, chosenJob))
+                continue;
+
+            _stationJobs.MakeJobUnlimited(chosenStation.Value, chosenJob);
+        }
+
+        /* Start of Harmony change. Removed to allow for Harmony specific Bureaucratic Error behavior.
         // Low chance to completely change up the late-join landscape by closing all positions except infinite slots.
         // Lower chance than the /tg/ equivalent of this event.
         if (RobustRandom.Prob(0.25f))
@@ -57,5 +72,6 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
                 _stationJobs.TryAdjustJobSlot(chosenStation.Value, chosenJob, RobustRandom.Next(-3, 6), clamp: true);
             }
         }
+        End of Harmony change of Bureaucratic Error event */
     }
 }

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -134,6 +134,10 @@
   - type: BureaucraticErrorRule
     ignoredJobs:
     - StationAi
+    # Begin Harmony specific bureaucratic error values
+    minimumJobs: 1
+    maximumJobs: 4
+    # End Harmony specific bureaucratic error values
 
 - type: entity
   id: ClericalError


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Reworked the Bureaucratic Error event to no longer remove job slots, instead picking a random number of jobs and setting them to have unlimited slots. By default, it will select between 1 and 4 job slots to give unlimited slots. (This can be changed via YAML on the gamerule prototype.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People were understandably not very fond of this event removing every slot of every job except for one and Passenger, especially if it removed a job they really wanted to play. This became a particularly frustrating issue when combined with the fact that it can affect command and security roles, and ran the risk of particularly bad survival rounds having 2 Security members and 9 Scientists or Botanists or something.
This seems like an acceptable change for now until the HoP gets some way to counteract this (either on Harmony or upstream.)

## Technical details
<!-- Summary of code changes for easier review. -->
- Added fields for `MinimumJobs` and `MaximumJobs` to the Bureaucratic Error gamerule component to allow for further adjustments to the event, since it now rolls a random number between minimum and maximum, then sets that many jobs to have unlimited slots.
- Changed the Bureaucratic Error gamerule system to pick a random number of jobs and set them to have unlimited slots. If it picks a job that is already unlimited, it will skip it.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reworked Bureaucratic Error event to only add infinite slots to a random number of jobs.
