### PR TITLE
Fix trinket comments

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -10,6 +10,7 @@
   - Headphones
   - PlushieLizard
   - PlushieSpaceLizard
+  - PlushieVox # Harmony
   - ThreeCandles
   - Lighter
   - CigPackGreen
@@ -36,7 +37,7 @@
   - ClothingNeckTransPin
   - ClothingNeckAutismPin
   - ClothingNeckGoldAutismPin
-#harmony specific trinkets
+  # Start harmony change - Server pins & neck slot items.
   - ClothingNeckVulturePin
   - ClothingNeckMirosPin
   - ClothingNeckLizardPin
@@ -48,6 +49,7 @@
   - ClothingNeckCosmaticDriftPin
   - ClothingNeckLanyard
   - HarmonicaInstrument
+  # End harmony change - Server pins & neck slot items.
   - TowelColorBlack
   - TowelColorDarkBlue
   - TowelColorDarkGreen
@@ -65,10 +67,8 @@
   - TowelColorWhite
   - TowelColorYellow
   - TowelStripedOrange # Harmony
-  - PlushieVox
   - Cane # Harmony
-#deltav specific trinkets
-  - TapeRecorder
+  - TapeRecorder # DeltaV / Harmony
 
 - type: loadoutGroup
   id: Glasses
@@ -1150,7 +1150,7 @@
   - DetectiveBlueCoatHarmony # Harmony
   - DetectiveBomberCoatHarmony # Harmony
   - DetectiveDiscoCoatHarmony # Harmony
- 
+
 - type: loadoutGroup
   id: SecurityCadetJumpsuit
   name: loadout-group-security-cadet-jumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1150,7 +1150,7 @@
   - DetectiveBlueCoatHarmony # Harmony
   - DetectiveBomberCoatHarmony # Harmony
   - DetectiveDiscoCoatHarmony # Harmony
-
+ 
 - type: loadoutGroup
   id: SecurityCadetJumpsuit
   name: loadout-group-security-cadet-jumpsuit


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Trinket comments now properly label every change as a harmony change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
