### PR TITLE
Increase role timers for seniority items

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobQuartermaster
-      time: 10800 #20 hrs
+      time: 16200 # Harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -5,7 +5,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobJanitor
-      time: 21600 #52 hrs (1 hour per week for 1 year)
+      time: 54000 # Harmony: 52 hrs -> 15 hrs (~10 rounds), intentionally high because it's made for insane players
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobPassenger
-      time: 10800 #10 hrs, silly reward for people who play passenger a lot
+      time: 10800 # harmony: 10 hrs -> 3 hrs (~2 rounds)
 
 # Head of Greytide (for grey mantle)
 - type: loadoutEffectGroup

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobCaptain
-      time: 10800 #20 hrs
+      time: 16200 # harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/head_of_personnel.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfPersonnel
-      time: 10800 #20 hrs
+      time: 16200 # harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Professional HoP Time
 - type: loadoutEffectGroup
@@ -16,7 +16,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfPersonnel
-      time: 7200 #15 hrs, special reward for HoP mains
+      time: 7200 # harmony: 15 hrs -> 2 hrs (~2 rounds)
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefEngineer
-      time: 10800 #20 hrs
+      time: 16200 # harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -6,17 +6,17 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 3600 #6 hrs
+      time: 10800 # harmony: 6 hrs -> 3 hrs (~2 rounds)
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobStationEngineer
-      time: 3600 #6 hrs
+      time: 10800 # harmony: 6 hrs -> 3 hrs (~2 rounds)
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Engineering
-      time: 10800 # 60 hrs
+      time: 108000 # Harmony: 60 hrs -> 30 hrs (~20 rounds)
 
 # Head
 - type: startingGear

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChiefMedicalOfficer
-      time: 10800 #20 hrs
+      time: 16200 # harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -6,17 +6,17 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobChemist
-      time: 3600 #6 hrs
+      time: 10800 # harmony: 6 hrs -> 3 hrs (~2 rounds)
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 3600 #6 hrs
+      time: 10800 # harmony: 6 hrs -> 3 hrs (~2 rounds)
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Medical
-      time: 10800 # 60 hrs
+      time: 108000 # Harmony: 60 hrs -> 30 hrs (~20 rounds)
 
 # Other Timers
 
@@ -27,7 +27,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 10800 #30 hrs
+      time: 54000 # Harmony: 30 hrs -> 15 hrs (~10 rounds)
 
 # Head
 

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobResearchDirector
-      time: 7200 #20 hrs
+      time: 16200 # harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Head
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:DepartmentTimeRequirement
       department: Science
-      time: 10800 #60 hrs
+      time: 108000 # Harmony: 60 hrs -> 30 hrs (~20 rounds)
 
 # Head
 - type: startingGear

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobHeadOfSecurity
-      time: 10800 #20 hrs
+      time: 16200 # harmony: 20 hrs -> 4.5 hrs (~3 rounds)
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -6,12 +6,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobWarden
-      time: 3600 #6 hrs
+      time: 10800 # harmony: 6 hrs -> 3 hrs (~2 rounds)
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Security
-      time: 10800 # 60 hrs
+      time: 108000 # Harmony: 60 hrs -> 30 hrs (~20 rounds)
 
 #Security Star
 - type: loadoutEffectGroup
@@ -21,7 +21,7 @@
       requirement:
         !type:DepartmentTimeRequirement
         department: Security
-        time: 21600 #100 hrs
+        time: 180000 # Harmony: 100 hrs -> 50 hrs (~34 rounds)
 
 # Head
 - type: loadout


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
This PR reincreases the role timers for seniority items.
The values are not definite and are subject to change.
This does **not** affect timers for the job themselves.

Needs to get approved by a project manager before merging.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe that, given how much the playerbase of harmony has increased in size massively since the reducing of those timers was done, we now have a need for items that show seniority in departments.
We now have a lot of players coming into harmony who are new players or may not play much of a single department and need to be able to see who most played in the department. ~~I also want to flex my playtime in departments.~~

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Playtime requirements for seniority items have been increased.