### PR TITLE
Ported Very Lightweight and Heavyweight drunk traits from Cosmic Drifts

### DIFF
--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -1,6 +1,6 @@
 cd-trait-category-drinking-skill = Alcohol Tolerance
 
-cd-trait-very-lightweight-name = Very Lightweight drunk
+cd-trait-very-lightweight-name = Very lightweight drunk
 cd-trait-very-lightweight-desc = Alcohol has a much stronger effect on you.
 
 cd-trait-heavyweight-name = Heavyweight drunk

--- a/Resources/Locale/en-US/_CD/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CD/traits/traits.ftl
@@ -1,0 +1,7 @@
+cd-trait-category-drinking-skill = Alcohol Tolerance
+
+cd-trait-very-lightweight-name = Very Lightweight drunk
+cd-trait-very-lightweight-desc = Alcohol has a much stronger effect on you.
+
+cd-trait-heavyweight-name = Heavyweight drunk
+cd-trait-heavyweight-desc = Alcohol has a weaker effect on you.

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -23,9 +23,11 @@
   - Paracusia
   - PermanentBlindness
   - Unrevivable
-  - Uncloneable #Harmony
+  - #Harmony Addition start
+  - Uncloneable
   - VeryLightweightDrunk #CD
   - HeavyweightDrunk #CD
+  - #Harmony Addition end
   # job specific
   - BibleUser
   - CommandStaff

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -24,6 +24,8 @@
   - PermanentBlindness
   - Unrevivable
   - Uncloneable #Harmony
+  - VeryLightweightDrunk #CD
+  - HeavyweightDrunk #CD
   # job specific
   - BibleUser
   - CommandStaff

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -12,7 +12,8 @@
   id: LightweightDrunk
   name: trait-lightweight-name
   description: trait-lightweight-desc
-  category: Quirks
+  category: DrinkingSkill # CD: Multiple levels
+  cost: 1 # CD: Multiple levels
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 2

--- a/Resources/Prototypes/Traits/quirks.yml
+++ b/Resources/Prototypes/Traits/quirks.yml
@@ -12,8 +12,10 @@
   id: LightweightDrunk
   name: trait-lightweight-name
   description: trait-lightweight-desc
+  #Harmony Addition start
   category: DrinkingSkill # CD: Multiple levels
   cost: 1 # CD: Multiple levels
+  #Harmony Addition end
   components:
   - type: LightweightDrunk
     boozeStrengthMultiplier: 2

--- a/Resources/Prototypes/_CD/Traits/categories.yml
+++ b/Resources/Prototypes/_CD/Traits/categories.yml
@@ -1,0 +1,4 @@
+- type: traitCategory
+  id: DrinkingSkill
+  name: cd-trait-category-drinking-skill
+  maxTraitPoints: 1

--- a/Resources/Prototypes/_CD/Traits/traits.yml
+++ b/Resources/Prototypes/_CD/Traits/traits.yml
@@ -1,0 +1,19 @@
+- type: trait
+  id: VeryLightweightDrunk
+  name: cd-trait-very-lightweight-name
+  description: cd-trait-very-lightweight-desc
+  category: DrinkingSkill
+  cost: 1
+  components:
+    - type: LightweightDrunk
+      boozeStrengthMultiplier: 4
+
+- type: trait
+  id: HeavyweightDrunk
+  name: cd-trait-heavyweight-name
+  description: cd-trait-heavyweight-desc
+  category: DrinkingSkill
+  cost: 1
+  components:
+    - type: LightweightDrunk
+      boozeStrengthMultiplier: 0.5


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Added two new alcohol theme traits the very lightweight and heavyweight traits. Originally from Cosmic Drift [#511](https://github.com/cosmatic-drift-14/cosmatic-drift/pull/511)

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new traits categories for the three alcohol traits.

very lightweight make you 4x booze strength
Heavyweight make you .5x booze strength

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/2b28a847-4034-41f5-adf4-90aca4ee8f4f)


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added two new alcohol theme traits
