### PR TITLE
Remove snail space immunity

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -375,7 +375,7 @@
     - type: SalvageMobRestrictions
 
 - type: entity
-  parent: SimpleSpaceMobBase
+  parent: SimpleMobBase # Harmony - Changed parent to non-spaceproof version.
   id: MobSnail
   name: snail
   description: Revolting unless you're french.


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Removed fun by making snails no longer space immune.

## Why / Balance
Snails going in space and running around the edge of the station until they can blow up the landmines on barratry or box is shitty.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Jajsha
- fix: Snails are no longer space immune.
