### PR TITLE
The Noctening - Increases nocturine price, decreases hypopen price

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -560,9 +560,9 @@
   productEntity: HypopenBox
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 4
+    Telecrystal: 2 # Harmony change
   cost:
-    Telecrystal: 6
+    Telecrystal: 4 # Harmony change
   categories:
   - UplinkChemicals
 
@@ -621,9 +621,9 @@
   productEntity: ChemistryBottleNocturine
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 6 # Harmony change
   cost:
-    Telecrystal: 6
+    Telecrystal: 8 # Harmony change
   categories:
   - UplinkChemicals
 


### PR DESCRIPTION
## About the PR
Title. 

## Why / Balance
Pretty thoroughly dicussed before so maybe I shouldn't write 50 paragraphs here, but the biggest complaint about the noct hypopen combo is the actual chem in itself and how uncounterable it is compared to other methods.

The hypopen has very healthy utility and still requires a fair amount of prep to be useful so I don't think it should be priced high just because another item exists which makes it extremely good. 

This doesn't actually increase or decrease the total cost of the kit, just redistributes the costs of the invididual items.

## Technical details
literally 4 line changes

## Media

![obraz](https://github.com/user-attachments/assets/fc3b1bda-6cf6-40c9-a28b-b6b9609b9ec9)
![obraz](https://github.com/user-attachments/assets/2475f683-69ed-4be9-9412-96609851f906)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Buffed hypopen price to 4 TC, nerfed nocturine price to 8 TC
