### PR TITLE
Added filled nitrogen tank to head lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -295,6 +295,7 @@
     - id: ClothingMaskBreath
     - id: ClothingOuterHardsuitRd
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled #Harmony addition
 
 # No hardsuit locker
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -75,7 +75,7 @@
     - id: ClothingMaskGasCaptain
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled
-    - id: NitrogenTankFilled
+    - id: NitrogenTankFilled #Harmony addition
 
 # No laser locker, used when the antique laser is placed in the special display crate
 - type: entity
@@ -183,7 +183,7 @@
     - id: ClothingShoesBootsMagAdv
     - id: JetpackVoidFilled
     - id: OxygenTankFilled
-    - id: NitrogenTankFilled
+    - id: NitrogenTankFilled #Harmony addition
 
 # No hardsuit locker
 - type: entity
@@ -242,7 +242,7 @@
     - id: ClothingMaskBreathMedical
     - id: ClothingOuterHardsuitMedical
     - id: OxygenTankFilled
-    - id: NitrogenTankFilled
+    - id: NitrogenTankFilled #Harmony addition
 
 # No hardsuit locker
 - type: entity
@@ -356,7 +356,7 @@
     - id: ClothingOuterHardsuitSecurityRed
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
-    - id: NitrogenTankFilled
+    - id: NitrogenTankFilled #Harmony addition
 
 # No hardsuit locker
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -75,6 +75,7 @@
     - id: ClothingMaskGasCaptain
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
 
 # No laser locker, used when the antique laser is placed in the special display crate
 - type: entity
@@ -182,6 +183,7 @@
     - id: ClothingShoesBootsMagAdv
     - id: JetpackVoidFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
 
 # No hardsuit locker
 - type: entity
@@ -240,6 +242,7 @@
     - id: ClothingMaskBreathMedical
     - id: ClothingOuterHardsuitMedical
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
 
 # No hardsuit locker
 - type: entity
@@ -353,6 +356,7 @@
     - id: ClothingOuterHardsuitSecurityRed
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
+    - id: NitrogenTankFilled
 
 # No hardsuit locker
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Added a filled nitrogen tank to any head locker that already contained a filled oxygen tank.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Due to only containing a filled oxygen tank, slimes and voxes playing head rolls have to search for a nitrogen tank if they do not already possess one. This can be deadly in emergencies! Adding nitrogen tanks, as an accompaniment to the oxygen tanks, seemed a reasonable QoL addition.

## Technical details
<!-- Summary of code changes for easier review. -->
Added id: NitrogenTankFilled in lockers containing id: OxygenTankFilled in Resources/Prototypes/Catalog/Fills/Lockers/heads.yml.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

There are no breaking changes at this time.
