### PR TITLE
Floodlights in Engi-vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -10,6 +10,7 @@
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
     ClothingHeadHatCone: 4
+    Floodlight: 2
   contrabandInventory:
     CowToolboxFilled: 1
     DrinkBeerCan: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -10,7 +10,7 @@
     ClothingHandsGlovesColorYellow: 6
     BoxInflatable: 2
     ClothingHeadHatCone: 4
-    Floodlight: 2
+    Floodlight: 2 #Harmony addition
   contrabandInventory:
     CowToolboxFilled: 1
     DrinkBeerCan: 3


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Added two floodlights to the engi-vend.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Engineering could benefit from an additional, readily accessible light source. Flood lights become available later, but this should help relieve early-round annoyance at breaches. I've only provided two, as batteries are rechargeable and floodlights should feel like a limited resource.

## Technical details
<!-- Summary of code changes for easier review. -->
Added Floodlight: 2 to Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

There are no breaking changes!