### PR TITLE
Added nuclear codes for DAGD objective

### DIFF
--- a/Content.Server/_Harmony/Objectives/Components/StoreUnlockerComponent.cs
+++ b/Content.Server/_Harmony/Objectives/Components/StoreUnlockerComponent.cs
@@ -1,0 +1,15 @@
+using Content.Server._Harmony.Store.Conditions;
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Harmony.Objectives.Components;
+
+/// <summary>
+/// Unlocks store listings that use <see cref="ObjectiveUnlockCondition"/>.
+/// </summary>
+[RegisterComponent]
+public sealed partial class StoreUnlockerComponent : Component
+{
+    [DataField(required: true)]
+    public List<ProtoId<ListingPrototype>> Listings = new();
+}

--- a/Content.Server/_Harmony/Objectives/Systems/StoreUnlockerSystem.cs
+++ b/Content.Server/_Harmony/Objectives/Systems/StoreUnlockerSystem.cs
@@ -1,0 +1,34 @@
+using Content.Server.Objectives.Components;
+using Content.Shared.Mind;
+
+namespace Content.Server._Harmony.Objectives.Systems;
+
+/// <summary>
+/// Provides api for listings with <c>ObjectiveUnlockRequirement</c> to use.
+/// </summary>
+public sealed class StoreUnlockerSystem : EntitySystem
+{
+    private EntityQuery<Components.StoreUnlockerComponent> _query;
+
+    public override void Initialize()
+    {
+        _query = GetEntityQuery<Components.StoreUnlockerComponent>();
+    }
+
+    /// <summary>
+    /// Returns true if a listing id is unlocked by any objectives on a mind.
+    /// </summary>
+    public bool IsUnlocked(MindComponent mind, string id)
+    {
+        foreach (var obj in mind.Objectives)
+        {
+            if (!_query.TryComp(obj, out var comp))
+                continue;
+
+            if (comp.Listings.Contains(id))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/_Harmony/Store/Conditions/ObjectiveUnlockCondition.cs
+++ b/Content.Server/_Harmony/Store/Conditions/ObjectiveUnlockCondition.cs
@@ -1,0 +1,21 @@
+using Content.Server._Harmony.Objectives.Systems;
+using Content.Shared.Mind;
+using Content.Shared.Store;
+
+namespace Content.Server._Harmony.Store.Conditions;
+
+/// <summary>
+/// Requires that the buyer have an objective that unlocks this listing.
+/// </summary>
+public sealed partial class ObjectiveUnlockCondition : ListingCondition
+{
+    public override bool Condition(ListingConditionArgs args)
+    {
+        var minds = args.EntityManager.System<SharedMindSystem>();
+        if (!minds.TryGetMind(args.Buyer, out _, out var mind))
+            return false;
+
+        var unlocker = args.EntityManager.System<StoreUnlockerSystem>();
+        return unlocker.IsUnlocked(mind, args.Listing.ID);
+    }
+}

--- a/Resources/Locale/en-US/_Harmony/store/categories.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/categories.ftl
@@ -1,0 +1,1 @@
+store-category-objectives = Objectives

--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -15,3 +15,6 @@ uplink-hyposhell-desc = A box containing four hyposhells, shotgun shells that ca
 
 uplink-defib-name = Interdyne Defibrillator
 uplink-defib-desc = A compact defibrillator. It can be used to revive your fellow comrades, or as an effective melee weapon! You should probably throw away your acidifier if you expect to use this.
+
+uplink-nuke-codes-name = Nuclear authentication codes
+uplink-nuke-codes-desc = A folder containing a closely guarded secret. Now all you need is the disk. Good luck!

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -76,6 +76,11 @@
   - type: ObjectiveLimit
     limit: 1 # Not everyone gets to run it down!
     # End Harmony specific change
+    # Begin Harmony Specific change
+  - type: StoreUnlocker
+    listings:
+    - UplinkNuclearAuthenticationCodes
+    # End Harmony specific change
 
 #- type: entity
 #  parent: [BaseTraitorObjective, BaseLivingObjective]

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -16,6 +16,7 @@
     - UplinkWearables
     - UplinkJob
     - UplinkPointless
+    - UplinkObjectives # Harmony addition
     currencyWhitelist:
     - Telecrystal
     balance:

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -126,3 +126,21 @@
     - Bartender
     - Zookeeper
 
+# Objective-specific
+- type: listing
+  id: UplinkNuclearAuthenticationCodes
+  name: uplink-nuke-codes-name
+  description: uplink-nuke-codes-desc
+  productEntity: BoxFolderNuclearCodes
+  categories:
+  - UplinkObjectives
+  cost:
+    Telecrystal: 25
+  conditions:
+  - !type:ObjectiveUnlockCondition
+  - !type:ListingLimitedStockCondition
+    stock: 1
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle

--- a/Resources/Prototypes/_Harmony/Store/categories.yml
+++ b/Resources/Prototypes/_Harmony/Store/categories.yml
@@ -1,0 +1,5 @@
+- type: storeCategory
+  id: UplinkObjectives
+  name: store-category-objectives
+  priority: 11
+


### PR DESCRIPTION
## About the PR
Butchers code from https://github.com/space-wizards/space-station-14/pull/26786 to implement objective exclusive items. (I take zero credit for writing any of this. Would I need to credit where I pulled the code from in the code? If someone could tell me that would be great)

Traitors can now buy nuke codes for 25 TC if they have the Die A Glorious Death objective.

## Why / Balance
Probably not too game breaking if a DAGD syndicate manages to get their hands on 25 TC and somehow pull off stealing the nuke disk and holding it versus the entire station. 

In addition it would provide a cooler ending to complete syndicate station takeovers. Flavor and gameplay wise I think it makes sense too.

If deemed too unbalanced the price can be increased to 30 TC since you CAN technically pull this off alone by butchering Renault.

## Technical details


## Media
No media yet, wip

## Requirements
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added the Objective category to uplink: Die A Glorious Death syndicates can now purchase nuclear authentication codes for a high price.
