### PR TITLE
Port DeltaV #3277, changing the ramping event schedule

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -1,10 +1,12 @@
 using Content.Shared.EntityTable.EntitySelectors;
+using System.Numerics; // DeltaV
 
 namespace Content.Server.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(RampingStationEventSchedulerSystem))]
 public sealed partial class RampingStationEventSchedulerComponent : Component
 {
+    /* DeltaV replaced with vector math
     /// <summary>
     ///     Average ending chaos modifier for the ramping event scheduler. Higher means faster.
     ///     Max chaos chosen for a round will deviate from this
@@ -27,6 +29,23 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
 
     [DataField]
     public float StartingChaos;
+    */
+    
+    /// <summary>
+    ///     DeltaV - Key points which determine during what period will events last on average.
+    ///     X is duration of the setting in minutes. Y is time until next event in minutes.
+    /// </summary>
+    [DataField(required: true)]
+    public List<Vector2> TimeKeyPoints = new()
+    {
+        new Vector2(0f, 1f)
+    };
+    
+    /// <summary>
+    ///     DeltaV - Maximum possible error when randomly offsetting time until next event.
+    /// </summary>
+    [DataField]
+    public float TimeDeviation = 1;
 
     [DataField]
     public float TimeUntilNextEvent;

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -401,6 +401,12 @@
   parent: BaseGameRule
   components:
   - type: RampingStationEventScheduler
+    timeKeyPoints: # DeltaV Start
+      - 14, 16
+      - 32, 8
+      - 32, 4
+      - 8, 2
+      - 32, 8 # DeltaV End
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Currently survival is a ramping challenge to point of zero breathing room with it exponentially keep getting worse. This PR, [#3277](https://github.com/DeltaV-Station/Delta-v/pull/3277) changes the scheduler to use set points to change how many events happen instead of it exponentially getting worse. Also this allows us to have better control of how difficult we want survival.

## Technical details
Taken from original PR:

A lot of commented code out in RampingStationEventSchedulerComponent.cs and RampingStationEventSchedulerSystem.cs.
Major tweak of interface towards RampingStationEventScheduler. Instead of 2 numbers, there is a list of 2D vectors and one number for randomness range.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Black is average time period between events for old system, red is new average.
![424651091-a4266153-ca41-4fef-a110-83c8f6f3fa68](https://github.com/user-attachments/assets/200821c4-df82-4a65-8e69-4abf5ce7a980)
Desmos graph [here](https://www.desmos.com/calculator/lrllp95exu).


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: changed the ramping scheduler
