### PR TITLE
Fix the eshotgun not being given

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -23,6 +23,7 @@
         amount: 2
       - id: RemoteSignaller
         amount: 2
+      - id: WeaponEnergyShotgun # Harmony Change: Gives the Warden the Energy Shotgun
 
 - type: entity
   id: LockerWardenFilled


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Fixed the eshotgun being missing in the warden locker variant with a hardsuit

