### PR TITLE
Mice Now Deal Damage one Blunt Damage When Thrown

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1808,6 +1808,20 @@
       Taco: RatTaco
       Burger: RatBurger
       Skewer: RatSkewer
+# Start of Harmony Change: Mice now deal damage when thrown, and take damage when they land
+  - type: DamageOtherOnHit
+    ignoreResistances: true
+    damage:
+      types:
+        Blunt: 1
+  - type: DamageOnLand
+    damage:
+      types:
+        Blunt: 5
+  - type: EmitSoundOnLand
+    sound:
+      collection: WeakHit
+# End of Harmony Change
 
 - type: entity
   parent: MobMouse

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1808,20 +1808,6 @@
       Taco: RatTaco
       Burger: RatBurger
       Skewer: RatSkewer
-# Start of Harmony Change: Mice now deal damage when thrown, and take damage when they land
-  - type: DamageOtherOnHit
-    ignoreResistances: true
-    damage:
-      types:
-        Blunt: 1
-  - type: DamageOnLand
-    damage:
-      types:
-        Blunt: 5
-  - type: EmitSoundOnLand
-    sound:
-      collection: WeakHit
-# End of Harmony Change
 
 - type: entity
   parent: MobMouse


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Mice Now Deal One Blunt Damage When Thrown
- They also take five blunt on impact
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Did a poll for it. People want it.
## Technical details
<!-- Summary of code changes for easier review. -->
Resources/Prototypes/Entities/Mobs/NPCs/animals.yml -- Adds damage values
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Mice Now Deal One Blunt Damage When Thrown
- tweak: Mice take five blunt damage on Impact when Thrown

