### PR TITLE
Nerf jetpack acceleration

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -51,6 +51,7 @@
         temperature: 293.15
     - type: Jetpack
       moleUsage: 0.00085
+      acceleration: 0.5
     - type: Appearance
     - type: StaticPrice
       price: 100


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Halved all jetpack acceleration.
Space dragon and other spacefaring mob acceleration is unchanged.

## Why / Balance
Space combat is currently problematic. 
Because space is an infinite plane, it is trivial for someone to come in, take a few shots, and then disengage. Even if the person going after them also has a jetpack, there is very little that can be done to actually catch up. They can then just escape and heal up, repeating infinitely. If the person chasing you does NOT have a jetpack, they're just literally unable to catch up or fight back.
Fighting in space in general also leads to situations where somoene gets gunned down (since you can't use nonlethals in space combat) and their body is flown at mach 5, leading in accidental round removal. 

This change reinforces the jetpack as a traversal tool rather than as a combat one. You will end up at the same max speed, it just takes longer to get there. 

## Technical details
Literally one number.

## Media
https://github.com/user-attachments/assets/137be8ea-5e83-414d-a4b3-26612788e19e

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Jajsha
- tweak: Halved all jetpack speed.
