### PR TITLE
Adds structural damage to the QM Knuckledusters

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -513,6 +513,7 @@
     damage:
       types:
         Blunt: 14
+        Structural: 10 # Harmony Change, Adds sturctural damage to allow the QM to use them as a stylish pickaxe
     soundHit:
       collection: Punch
     animation: WeaponArcFist


### PR DESCRIPTION
## About the PR
Adds 10 structural damage to the QM's Knuckledusters, allowing them to be used as a pickaxe for mining.

## Why / Balance
The flavourful feel of being able to break open rocks with your hands is really cool.

The dusters have an attack rate of 1.5.
 I ran a series of tests with the dusters versus Uplink items known for being good at breaking things - the Energy Sword and the Suspicious Toolbox. Ultimately, I felt 10 felt the best when breaking rocks while not approaching the esword, and being on equal footing to the toolbox.

> --10 STRUCT--
> Asteroid: 3 Punches (~2 seconds)
> Door: 40 Punches (~26.6 seconds)
> Caps Locker: 19 Punches (~12.6 seconds)
> Secure Crate: 19 Punches (~12.6 seconds)
> Regular Window: 3 Punches (~2 seconds)
> Reinforced Window: 17 punches (~11.3)
> plasma window: 4 punches (~2.6 seconds)
> reinforced plasma window: 34 punches (~22.6 seconds)
>
> _The seconds are derived from the punches and the attack rate, not timed, and such are estimates_

As these knuckledusters take up your glove slot, they can't be used to break through electrified grills.

With all that in mind, they function as a good tool for mining, give interesting alternatives for traitors who manage to get their hands on them, without incentivising doing that as a necessary play.

The QM also has stronger tools for mining if they want, but the flavour is undeniably strong for punching rocks open.

## Technical details
Adds the structural damage type to the QM's knuckledusters in upstream's gloves.yml

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The QM's golden knuckledusters can now be used to mine asteroids.
