### PR TITLE
Labeller tweaks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,7 +20,13 @@
 - changed-files:
   - any-glob-to-any-file: '**/*.ogg'
 
-"Changes: No C#":
+# Harmony start
+# "Changes: No C#":
+# - changed-files:
+#   # Equiv to any-glob-to-all as long as this has one matcher. If ALL changed files are not C# files, then apply label.
+#   - all-globs-to-all-files: "!**/*.cs"
+
+"Changes: C#":
 - changed-files:
-  # Equiv to any-glob-to-all as long as this has one matcher. If ALL changed files are not C# files, then apply label.
-  - all-globs-to-all-files: "!**/*.cs"
+  - any-glob-to-any-file: '**/*.cs'
+# Harmony end

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -11,4 +11,15 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    # Harmony start
+    - name: Get Current Labels
+      id: get_current_labels
+      uses: snnaplab/get-labels-action@v1.0.1
+      continue-on-error: true
+    # Harmony end
     - uses: actions/labeler@v5
+      # Harmony start
+      if: ${{ (env.LABELS == '') || (! contains(env.LABELS, 'Maintenance')) }}
+      with:
+        sync-labels: true
+      # Harmony end

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -12,9 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Harmony start
-    - name: Get Current Labels
-      id: get_current_labels
-      uses: snnaplab/get-labels-action@v1.0.1
+    - uses: snnaplab/get-labels-action@v1.0.1
       continue-on-error: true
     # Harmony end
     - uses: actions/labeler@v5

--- a/.github/workflows/labeler-pr.yml
+++ b/.github/workflows/labeler-pr.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Harmony start
+    - name: Automatic Maintenance Label
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'Upstream') || startsWith(github.event.pull_request.title, 'Changelog') }}
+      with:
+        labels: Maintenance
     - uses: snnaplab/get-labels-action@v1.0.1
       continue-on-error: true
     # Harmony end


### PR DESCRIPTION
- Labeller now uses `Changes: C#` instead of `Changes: No C#`
- Labeller now ignores all PRs with a maintenance tag
- Labeller will now remove labels if a change that was previously done is removed (e.g. PR was accidentally made with the changes of a previous PR and owner has removed them after)
- Labeller automatically adds a maintenance label to all PRs that start with 'Upstream' or 'Changelog'

I personally think that these changes would be make the labeller much simpler and less annoying to use than the current method where I need to constantly add or remove tags on maintenance PRs