### PR TITLE
Adds AstroNav to QM PDA

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -473,6 +473,16 @@
     accentVColor: "#a23e3e"
   - type: Icon
     state: pda-qm
+# Harmony Change Start, adds AstroNav to QM PDA and adds the necessary lines so the PDA keeps the basic cartridges
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NanoTaskCartridge
+      - NewsReaderCartridge
+      - AstroNavCartridge
+# Harmony Change End
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
## About the PR
Adds AstroNav as a preinstalled cartridge to the Quartermaster's PDA, allowing them to look at coordinates at round-start

## Why / Balance
Command parity. The other Heads of Department with PDA cartridges have them preinstalled, and while that is necessary for the CMO the HoS sets the precedent that cartridges for specialized jobs under them are still preinstalled with the Detective's Doorlogs.

The QM starts with an AstroNav cartridge in their locker, and frequently installs it anyway. This simply removes uneccesary friction and prevents newer QMs from being noob-trapped when lost in space thinking they would have coordinates available to them.

This also lets the QM aid newer salvagers better even on station, as they can quickly call out the cargo bay's coordinates now.

## Technical details
Adds the CartridgeLoader type to the QMs PDA on the upstream file pda.yml. As adding this redefines what cartridges are installed, also adds the Crew Manifest, Notekeeper, Nanotask, and News Reader cartridges to the QM PDA yml as well as the AstroNav.

## Media
![image](https://github.com/user-attachments/assets/2e9a8c54-1a07-408c-93e2-2734f79398c1)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The Quartermaster's PDA now starts with AstroNav installed, allowing them quick access to their coordinates.

