### PR TITLE
End explosive payload bombing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/payload.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/payload.yml
@@ -33,21 +33,23 @@
     maxIntensity: 10
     intensitySlope: 3
     totalIntensity: 120 # about a ~4 tile radius
-  - type: ExplodeOnTrigger
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 25
-      behaviors:
-      - !type:ExplodeBehavior
-    - trigger:
-        !type:DamageTrigger
-        damage: 50
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+  #Harmony change start-Remove payload explode on trigger
+  #- type: ExplodeOnTrigger
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTypeTrigger
+  #      damageType: Heat
+  #      damage: 25
+  #    behaviors:
+  #    - !type:ExplodeBehavior
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 50
+  #    behaviors:
+  #    - !type:DoActsBehavior
+  #      acts: [ "Destruction" ]
+  #Harmony change end
 
 - type: entity
   name: chemical payload


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Remove the ability for explosive payload to trigger without being made into a grenade.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It doesn't seem right that you trigger the payload without making it into a grenade, mind you can make duffel bag bomb but now you need to make signal trigger grenades.

## Technical details
<!-- Summary of code changes for easier review. -->
Committed out the ability to trigger when exploded.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- remove: Explosive payload ability to trigger

