### PR TITLE
Slows down blood red suit to increase elite suit effectiveness

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -577,8 +577,8 @@
         Radiation: 0.5
         Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.8 # Harmony Change 0.9 -> 0.8
+    sprintModifier: 0.8 # Harmony Change 0.9 -> 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndie


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Slowed down the blood red suit
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
previously the only thing keeping the syndicate elite suit "elite" was its speed buff, but it has long since been put on par with the blood-red
I think the elite suit should actually be elite in someway as an upgrade and not an alternative for heat res instead of pierce res

and a 5% diffrence still makes elite suits not a must have for syndicate agents, as the blood red still has a good speed advantage compared to other hardsuits. 
## Technical details
<!-- Summary of code changes for easier review. -->
Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml - changed 0.9 to 0.85
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/103bd875-8c25-4e24-9214-989c031b204b)
## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Blood-red hardsuits are now a bit slower
