### PR TITLE
Pizza bomb box

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -4,6 +4,9 @@ uplink-syndicate-id-desc = A sleek black-and-red ID card with embossed Syndicate
 uplink-pizza-bomb-name = Nefarious Pizza bomb
 uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the syndicate for eliminating high value targets
 
+uplink-pizza-bomb-surplus-name = Surplus Pizza Bomb
+uplink-pizza--surplus-desc = This shouldn't be visible, report me.
+
 uplink-traitor-deathrattle-implant-name = Box Of Deathrattle Implants
 uplink-traitor-deathrattle-implant-desc = A box containing two syndicate deathrattle implants. Messages are relayed over the syndicate channel, encryption keys not included.
 

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -49,7 +49,7 @@
 # packaging when acquired from a surplus crate.
 - type: listing
   id: UplinkPizzaBombSurplus
-  name: uplink-pizza-bomb-surplus-name #not needed, never listed in store
+  name: uplink-pizza-bomb-surplus-name
   description: uplink-pizza-bomb-surplus-desc
   productEntity: PizzabombSurplus
   cost:

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -39,6 +39,27 @@
     Telecrystal: 4
   categories:
   - UplinkExplosives
+  conditions:
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
+
+- type: listing
+  id: UplinkPizzaBombSurplus
+  name: uplink-pizza-bomb-surplus-name #not needed, never listed in store
+  description: uplink-pizza-bomb-surplus-desc
+  productEntity: PizzabombSurplus
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkExplosives
+  conditions:
+  - !type:BuyerWhitelistCondition
+    whitelist:
+      components:
+      - SurplusBundle
+
 
 # Ammo
 

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -45,6 +45,8 @@
       components:
       - SurplusBundle
 
+# The Pizzabomb is visually identical to the non-bomb version to avoid (more) accidents it comes in an informative
+# packaging when acquired from a surplus crate.
 - type: listing
   id: UplinkPizzaBombSurplus
   name: uplink-pizza-bomb-surplus-name #not needed, never listed in store

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Bombs/pizzabombbox.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Bombs/pizzabombbox.yml
@@ -5,6 +5,6 @@
   name: nefarious pizza bomb box
   description: Contains one nefarious pizza bomb. Does not contain pizza.
   components:
-    - type: StorageFill
-      contents:
-      - id: Pizzabomb
+  - type: StorageFill
+    contents:
+    - id: Pizzabomb

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Bombs/pizzabombbox.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Bombs/pizzabombbox.yml
@@ -5,6 +5,6 @@
   name: nefarious pizza bomb box
   description: Contains one nefarious pizza bomb. Does not contain pizza.
   components:
-      - type: StorageFill
-        contents:
-        - id: Pizzabomb
+    - type: StorageFill
+      contents:
+      - id: Pizzabomb

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Bombs/pizzabombbox.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Bombs/pizzabombbox.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: PizzabombSurplus
+  parent: CrateSyndicate
+  suffix: Filled
+  name: nefarious pizza bomb box
+  description: Contains one nefarious pizza bomb. Does not contain pizza.
+  components:
+      - type: StorageFill
+        contents:
+        - id: Pizzabomb


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Split the Pizza Bomb item uplink listing in two, limited the original to be unable to spawn in surplus crates, limited the new one to be only available from surplus crates. The new one spawns inside a syndicate crate that clearly marks it as a bomb, and not pizza.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a direct responce to #726, i am aware of three times agents have detonated their surplus crate due to the pizza bomb. That is less than ideal.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Sadly no new media, will make a new pr or update here if new media (pizza delivery bag) becomes available.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: a new listing to the syndicate uplink for a pizza bomb in a (clearly labled box, unable to be purchased, only available from surplus crates
- remove: the pizza bomb (without a box) from the surplus crate loot pool.
