### PR TITLE
Separate blood brother preference between initial and convertible

### DIFF
--- a/Content.Shared/_Harmony/BloodBrothers/Components/InitialBloodBrotherComponent.cs
+++ b/Content.Shared/_Harmony/BloodBrothers/Components/InitialBloodBrotherComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class InitialBloodBrotherComponent : Component
     /// If null, the check will be skipped.
     /// </summary>
     [DataField]
-    public ProtoId<AntagPrototype>? RequiredAntagPreference = "BloodBrother";
+    public ProtoId<AntagPrototype>? RequiredAntagPreference = "BloodBrotherConvertible";
 
     /// <summary>
     /// The popup that will happen when a blood brother is converted.

--- a/Resources/Locale/en-US/_Harmony/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_Harmony/prototypes/roles/antags.ftl
@@ -1,2 +1,3 @@
-roles-antag-blood-brother-name = Blood Brother
+roles-antag-blood-brother-name = Blood Brother (Initial)
+roles-antag-blood-brother-convertible-name = Blood Brother (Converted)
 roles-antag-blood-brother-objective = Collaborate with your blood brother to accomplish all your objectives.

--- a/Resources/Prototypes/_Harmony/Roles/Antags/bloodbrother.yml
+++ b/Resources/Prototypes/_Harmony/Roles/Antags/bloodbrother.yml
@@ -8,3 +8,14 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 3600 # 1h
+
+# not actually given out, only used to check the preference
+- type: antag
+  id: BloodBrotherConvertible
+  name: roles-antag-blood-brother-convertible-name
+  setPreference: true
+  objective: roles-antag-blood-brother-objective
+  guides: [ BloodBrothers ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1h


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
See title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some players may want to be possible to convert into blood brothers while also not wanting to be the initial blood brother due to lore reason or even personal preference.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a second antag prototype that is *not* given out and replaced the old blood brother preference from the convertible check to the new preference.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![bb_selection_moment](https://github.com/user-attachments/assets/cab7b16a-e716-453d-b57d-d30cb2bede57)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The blood brother antag selection preference has been split off into the initial and converted preference.