### PR TITLE
Adds Ammo to the Drozd and Kammerer Crates

### DIFF
--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml
@@ -56,6 +56,8 @@
     contents:
     - id: WeaponSubMachineGunDrozd
       amount: 2
+    - id: MagazinePistolSubMachineGun
+      amount: 4
 
 - type: entity
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
@@ -68,3 +70,5 @@
     contents:
     - id: WeaponShotgunKammerer
       amount: 2
+    - id: BoxLethalshot
+      amount: 4


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Adds four SMG mags to the SMG crate
- Adds four lethal shotgun boxes to the shotgun crate
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, the new cargo armory crates aren't worth buying without ammo being included. This causes crew to be even more helpless when the armory is lost.

## Technical details
<!-- Summary of code changes for easier review. -->
### _Harmony Namescape
Resources/Prototypes/_Harmony/Catalog/Fills/Crates/armory.yml -- Adds ammo to cargo armory crates
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Adds ammo back to the SMG and shotgun crates
