### PR TITLE
Doors No Longer Connect to Walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -158,9 +158,11 @@
     - board
   - type: PlacementReplacement
     key: walls
-  - type: IconSmooth
-    key: walls
-    mode: NoSprite
+# Start of Harmony Change: Removes IconSmoothing from Airlocks
+#  - type: IconSmooth
+#    key: walls
+#    mode: NoSprite
+# End of Harmony Change
   - type: PaintableAirlock
     group: Standard
     department: Civilian

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml
@@ -115,9 +115,11 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    mode: NoSprite
+# Start of Harmony Change: Removes IconSmoothing from High Security Doors
+#  - type: IconSmooth
+#    key: walls
+#    mode: NoSprite
+# End of Harmony Change
   - type: Construction
     graph: Airlock
     node: highSecDoor

--- a/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml
@@ -55,9 +55,11 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    mode: NoSprite
+# Start of Harmony Change: Removes IconSmoothing from Material Doors
+#  - type: IconSmooth
+#    key: walls
+#    mode: NoSprite
+# End of Harmony Change
   - type: Occluder
   - type: BlockWeather
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -76,9 +76,11 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-  - type: IconSmooth
-    key: walls
-    mode: NoSprite
+# Start of Harmony Change: Removes IconSmoothing from Shutters
+#  - type: IconSmooth
+#    key: walls
+#    mode: NoSprite
+# End of Harmony Change
   - type: DoorSignalControl
   - type: DeviceNetwork
     deviceNetId: Wireless


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
- Doors No Longer Connect to Walls
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
An artistic change suggested by one of our project managers.
## Technical details
<!-- Summary of code changes for easier review. -->
### Upstream Files
Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml -- Removes Icon Smoothing Component
Resources/Prototypes/Entities/Structures/Doors/Airlocks/highsec.yml -- Removes Icon Smoothing Component
Resources/Prototypes/Entities/Structures/Doors/MaterialDoors/material_doors.yml -- Removes Icon Smoothing Component
Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml -- Removes Icon Smoothing Component

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/6cf7ffd2-cbce-409f-9cc2-cd3c054d44ad)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Made doors no longer connect to walls
