### PR TITLE
Re-Adds Salvage Gear To Debris And VGroid Spawn Pools

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -236,7 +236,7 @@
     - id: Fulton
       amount: !type:RangeNumberSelector
         range: 1, 3
-    - id: HandHeldMassScanner
+  # - id: HandHeldMassScanner - Harmony change - Removes from Salvage loot pools
     - id: WeaponCrusherDagger
     - id: MiningDrill
     - id: ClothingEyesGlassesMeson

--- a/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
+++ b/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
@@ -96,7 +96,10 @@
     entities:
     - SalvageSpawnerTreasure
     - SalvageSpawnerTreasure
+    - SalvageSpawnerEquipment #Harmony Specific Change, adds equipment back to the lootpool.
+    - SalvageSpawnerEquipment #Harmony Specific Change, adds equipment back to the lootpool.
     - SalvageSpawnerTreasureValuable
+    - SalvageSpawnerEquipmentValuable #Harmony Specific Change, adds equipment back to the lootpool.
   - !type:BiomeEntityLayer
     allowedTiles:
     - FloorSteel

--- a/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
+++ b/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
@@ -96,10 +96,10 @@
     entities:
     - SalvageSpawnerTreasure
     - SalvageSpawnerTreasure
+    - SalvageSpawnerTreasureValuable
     # Begin Harmony Specific Changes - adds equipment Back to lootpool.
     - SalvageSpawnerEquipment
     - SalvageSpawnerEquipment
-    - SalvageSpawnerTreasureValuable
     - SalvageSpawnerEquipmentValuable
     # End Harmony Specific Changes - adds equipment back to lootpool.
   - !type:BiomeEntityLayer

--- a/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
+++ b/Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml
@@ -96,10 +96,12 @@
     entities:
     - SalvageSpawnerTreasure
     - SalvageSpawnerTreasure
-    - SalvageSpawnerEquipment #Harmony Specific Change, adds equipment back to the lootpool.
-    - SalvageSpawnerEquipment #Harmony Specific Change, adds equipment back to the lootpool.
+    # Begin Harmony Specific Changes - adds equipment Back to lootpool.
+    - SalvageSpawnerEquipment
+    - SalvageSpawnerEquipment
     - SalvageSpawnerTreasureValuable
-    - SalvageSpawnerEquipmentValuable #Harmony Specific Change, adds equipment back to the lootpool.
+    - SalvageSpawnerEquipmentValuable
+    # End Harmony Specific Changes - adds equipment back to lootpool.
   - !type:BiomeEntityLayer
     allowedTiles:
     - FloorSteel

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -163,15 +163,29 @@
     table: !type:NestedSelector
       tableId: SalvageScrapSpawnerValuable
   - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 45
+    minCount: 15 #Harmony Change - 30 --> 15 - reverts changes made in upstream pr #37561
+    maxCount: 25 #Harmony Change - 45 --> 25 - reverts changes made in upstream pr #37561
     table: !type:NestedSelector
       tableId: SalvageTreasureSpawnerCommon
   - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 45
+  #Start of Harmony specific changes - adds back salvage equipment
+    minCount: 15
+    maxCount: 25
+    table: !type:NestedSelector
+      tableId: SalvageEquipmentSpawnerCommon
+  - !type:EntityTableDunGen
+    minCount: 15
+    maxCount: 20
+  #End of Harmony specific changes - adds back salvage equipment
     table: !type:NestedSelector
       tableId: SalvageTreasureSpawnerValuable
+      #Start of Harmony specific changes - adds back salvage equipment
+  - !type:EntityTableDunGen
+    minCount: 15
+    maxCount: 20
+    table: !type:NestedSelector
+      tableId: SalvageEquipmentSpawnerValuable
+      #End of Harmony specific changes - adds back salvage equipment
   - !type:MobsDunGen
     minCount: 8
     maxCount: 15


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
This PR is intended to revert part of the changes made in https://github.com/space-wizards/space-station-14/pull/37561 , which removed salvage equipment from debris and the VGroid. This left only the double emergency tank as an item that could naturally spawn thanks to its nature as a maintenance lootpool item.

Currently, the lootpool for items that help improve the upgrade path for salvagers would be limited to static spawns on wrecks, meaning salvagers are more focused on pulling wrecks for items like Mining Suits, Crushers, or Double Emergency Tanks - at the detriment of the stations material supply.

A noteable change from how things were before is leaving out mass scanners from the lootpool. This is to encourage cooperation between Science and Salvage, as Mass Scanners are one of the few station produceable upgrades for Salvage.

PKA mod kits have not been removed, as there is an element of randomess to getting the mods you actually want.  Also, despite being a Tier 1 Tech on harmony - they are aresenal, and therefore very rarely researched outside of War Ops (in which case you will eskew your PKA for an actual decent firearm, like an Energy Carbine, X-Ray Cannon, or your preferred flavor of ballistic weaponary.)

## Why / Balance
Overview covers much of my reasoning, but in brief:
-Adds back progression paths to salvage outside of the salvage job board, which is a current point of friction for salvage.
-Adds back a sense of the "rogue-like" feel to salvaging with random gear upgrades that many salvage players say is a core driving factor of their enjoyment of the job.
-Much of the equipment added back in has recieved adjustments since it was made harder to acquire. I don't think adding them back to the loot pool is going to shift the power dynamic back in salvage-antags favour massively.
-Provides another carrot on a stick for salvage to ensure that debris are being run, meaning materials are coming into the station.

## Technical details
-Modifies upstream file Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml to comment out handheld mass scanners.
-Modifies upstream file Resources/Prototypes/Procedural/Magnet/space_debris_templates.yml to add back SalvageSpawnerEquipment to the spawnable items pool.
-Modifies upstream file Resources/Prototypes/Procedural/vgroid.yml to add back SalvageEquipmentSpawnerCommon and SalvageEquipmentSpawnerValuable items to the spawnable loot. Also adjusts SalvageScrapSpawnerValuable and SalvageTreasureSpawnerCommon back down to the pre-lootpool removal values.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Re-added Salvage equipment to the Debris and VGroid loot pools.

