### PR TITLE
Renames the healing nuclear operative role to Combat Medic

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -31,5 +31,5 @@ nukeops-not-enough-ready-players = Not enough players readied up for the game! T
 nukeops-no-one-ready = No players readied up! Can't start Nukeops.
 
 nukeops-role-commander = Commander
-nukeops-role-agent = Corpsman
+nukeops-role-agent = Combat Medic
 nukeops-role-operator = Operator

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
@@ -31,5 +31,6 @@ nukeops-not-enough-ready-players = Not enough players readied up for the game! T
 nukeops-no-one-ready = No players readied up! Can't start Nukeops.
 
 nukeops-role-commander = Commander
+## Harmony Change - Nukie Corpsman > Nuke Combat Medic
 nukeops-role-agent = Combat Medic
 nukeops-role-operator = Operator

--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -27,6 +27,7 @@ roles-antag-suspicion-suspect-objective = Kill the innocents.
 roles-antag-nuclear-operative-commander-name = Nuclear operative commander
 roles-antag-nuclear-operative-commander-objective = Lead your team to the destruction of the station.
 
+## Harmony Change - Nukie Corpsman > Nuke Combat Medic
 roles-antag-nuclear-operative-agent-name = Nuclear operative combat medic
 roles-antag-nuclear-operative-agent-objective = Like default operative, the team's treatment will have priority.
 

--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -27,7 +27,7 @@ roles-antag-suspicion-suspect-objective = Kill the innocents.
 roles-antag-nuclear-operative-commander-name = Nuclear operative commander
 roles-antag-nuclear-operative-commander-objective = Lead your team to the destruction of the station.
 
-roles-antag-nuclear-operative-agent-name = Nuclear operative corpsman
+roles-antag-nuclear-operative-agent-name = Nuclear operative combat medic
 roles-antag-nuclear-operative-agent-objective = Like default operative, the team's treatment will have priority.
 
 roles-antag-nuclear-operative-name = Nuclear operative

--- a/Resources/Locale/en-US/random-metadata/random-metadata-formats.ftl
+++ b/Resources/Locale/en-US/random-metadata/random-metadata-formats.ftl
@@ -12,7 +12,8 @@ name-format-dragon = {$part0} {$part1}
 
 # "<title> <name>"
 name-format-nukie-generic = {$part0} {$part1}
-name-format-nukie-agent = Agent {$part0}
+## Harmony Change - Nukie Corpsman > Nuke Combat Medic
+name-format-nukie-agent = Combat Medic {$part0}
 name-format-nukie-commander = Commander {$part0}
 name-format-nukie-operator = Operator {$part0}
 # "<title> <name>"

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -214,7 +214,7 @@
   parent: [ClothingEyesBase, ShowSecurityIcons, BaseSyndicateContraband]
   id: ClothingEyesHudSyndicateAgent
   name: syndicate medical visor
-  description: The Syndicate Corpsman's professional heads-up display, designed for quick diagnosis of their team's status.
+  description: The Syndicate Combad Medic's professional heads-up display, designed for quick diagnosis of their team's status. # Harmony Change - Nukie Corpsman > Nuke Combat Medic
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/syndagent.rsi

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1448,7 +1448,7 @@
 - type: entity
   parent: [ BaseMedicalPDA, BaseSyndicateContraband ]
   id: SyndiAgentPDA
-  name: syndicate corpsman PDA
+  name: syndicate combat medic PDA # Harmony Change - Nukie Corpsman > Nuke Combat Medic
   description: For those days when healing normal syndicates aren't enough, try healing nuclear operatives instead!
   components:
   - type: Pda

--- a/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/decoys.yml
@@ -83,8 +83,8 @@
 - type: entity
   parent: BaseDecoy
   id: BalloonAgent
-  name: corpsman balloon
-  description: Upon closer inspection, this Syndicate corpsman is actually a balloon.
+  name: combat medic balloon # Harmony Change - Nukie Corpsman > Nuke Combat Medic
+  description: Upon closer inspection, this Syndicate combat medic is actually a balloon. # Harmony Change - Nukie Corpsman > Nuke Combat Medic
   components:
   - type: Sprite
     sprite: Objects/Tools/Decoys/agent_decoy.rsi


### PR DESCRIPTION
## About the PR
Renames Nuclear Operative Corpsman to Nuclear Operative Combat Medic.

## Why / Balance
While https://github.com/space-wizards/space-station-14/pull/34627 correctly identified the issues with the name 'Agent', the proposed and accepted replacement term (Corpsman) comes with its own issues.
Namely, it still doesn't actually tell you what the role does unless you happen to be into the topic of militaries.
Alongside this, Corpsman carries with it an unnecessary gendered connotation that will inevitably alienate a portion of players that the game as a whole frequently demonstrates support for.
Finally, there is the potential confusing IC overlap for characters with RMC lore.

I have gone with Combat Medic, it is descriptive and to the point. While no name will ever be perfect, I think this is the best fit we have found.
Discussion around the original change to corpsman [in Harmony channels](https://discord.com/channels/1139716325627932682/1206781505158778910/1362895542417489980) also favoured this name.

## Technical details
Changes all instances of corpsman to combat medic in
- Resources/Locale/en-US/game-ticking/game-presets/preset-nukeops.ftl
- Resources/Locale/en-US/prototypes/roles/antags.ftl
- Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
- Resources/Prototypes/Entities/Objects/Devices/pda.yml
- Resources/Prototypes/Entities/Objects/Tools/decoys.yml

Changes one leftover instance of agent to combat medic in
- Resources/Locale/en-US/random-metadata/random-metadata-formats.ftl

## Media
![Screenshot 2025-06-14 232300](https://github.com/user-attachments/assets/e771fc2f-a518-40ae-ba03-364a45eabb38)
![Screenshot 2025-06-14 232323](https://github.com/user-attachments/assets/fd04acdd-5a05-4364-bb33-fae80a3a547a)
![Screenshot 2025-06-14 232348](https://github.com/user-attachments/assets/64c58674-145e-43f8-bbc8-ed2e9b7cf473)
![Screenshot 2025-06-14 233339](https://github.com/user-attachments/assets/c610c754-2015-4dfc-9d5a-71504725c04d)


## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The healing-focused Nuclear Operative is now called the Nuclear Operative Combat Medic.

