### PR TITLE
Re-reverts Upstream PR #31970 - Makes Coins Scrappable Again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
@@ -150,6 +150,11 @@
     state: coin_iron
   - type: Item
     size: Tiny
+    #Start Harmony Change - Make Scrappable
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 300
+    #End Harmony Change - Make Scrappable
   - type: StaticPrice
     price: 75
 
@@ -159,6 +164,12 @@
   components:
   - type: Sprite
     state: coin_silver
+#Start Harmony Change - Make Scrappable
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100
+      Silver: 200
+#End Harmony Change - Make Scrappable
   - type: StaticPrice
     price: 125
 
@@ -168,6 +179,12 @@
   components:
   - type: Sprite
     state: coin_gold
+#Begin Harmony Change - Make Scrappable
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 100
+      Gold: 200
+#End Harmony Change - Make Scrappable
   - type: StaticPrice
     price: 175
 
@@ -177,6 +194,12 @@
   components:
   - type: Sprite
     state: coin_adamantine
+#Begin Harmony Changes - Make Scrappable
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 400
+      Diamond: 5
+#End Harmony Changes - Make Scrappable
   - type: StaticPrice
     price: 250
 
@@ -186,6 +209,11 @@
   components:
   - type: Sprite
     state: coin_diamond
+#Begin Harmony Changes - Make Scrappable
+  - type: PhysicalComposition
+    materialComposition:
+      Steel: 300
+      Diamond: 15
+#End Harmony Changes - Make Scrappable
   - type: StaticPrice
     price: 500
-


### PR DESCRIPTION
## About the PR
Reverts changes made to upstream files in https://github.com/space-wizards/space-station-14/pull/37149, which is a reversion of https://github.com/space-wizards/space-station-14/pull/31970. This reversion is being made in light of requests from Harmony salvage players, as many miss the ability to scrap coins for useful roundstart gold and silver - especially now that mined gold/silver ore may end up being tossed into the salvage job board, so would not be seen by other departments across the station.

I have chosen to not rollback the other changes in https://github.com/space-wizards/space-station-14/pull/37149, namely the changes to rings and the CPU. 

Rings are now a cargo bounty on upstream, and by extension Harmony, and having bounty targets scrapped because of neglience would be frustrating. Also, they're part of the Harmony loadout system and we probably don't want to encourage people to be bringing rings just to scrap for a bit of materials roundstart.

The CPU has been left out, as the materials gained from scrapping it were not enough to justify scrapping compared to selling, especially for how rare it is. In lieu of making extensive changes to make it worth scrapping, or messing with its prices, I've decided to just focus on the coins for now - in favor of a long-term goal of refactoring the scrappable items for salvage to ensure they're inline with what is expected (to be raised in another PR in the future).

## Why / Balance
Many Salvage players, myself included, feel that his has eaten into the availability of gold and silver in the early parts of a round, especially as more items have been added to lower tier techs that want gold and silver (such as PKA mods). It also feels like a noticeable reduction in the amount of gold and silver sources available to Salvage after the introduction of the job board system, where gold and silver may be funneled into that instead of procured for the station.

By adding back in the ability to scrap coins, we can ensure that there is still a flow of gold and silver if Salvage choose to engage with the job board and doesn't mean Cargo has to buy materials and surplant salvage ( a common sore point for both sides of Supply).

## Technical details
Modifies Resources/Prototypes/Entities/Objects/Misc/treasure.yml to add back the PhysicalComposition field, as well as relevant subfields for what the coins can be broken down into, and how much.

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Made coins scrappable again.


