### PR TITLE
Adds binoculars to all Warden lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -24,6 +24,7 @@
       - id: RemoteSignaller
         amount: 2
       - id: WeaponEnergyShotgun # Harmony Change: Gives the Warden the Energy Shotgun
+      - id: Binoculars # Harmony Change: Added missing binoculars
 
 - type: entity
   id: LockerWardenFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -23,8 +23,8 @@
         amount: 2
       - id: RemoteSignaller
         amount: 2
-      - id: WeaponEnergyShotgun # Harmony Change: Gives the Warden the Energy Shotgun
       - id: Binoculars # Harmony Change: Added missing binoculars
+      - id: WeaponEnergyShotgun # Harmony Change: Gives the Warden the Energy Shotgun
 
 - type: entity
   id: LockerWardenFilled


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Added binoculars to LockerWardenFilledHardsuit prototype where it was previously missing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Warden is supposed to get binoculars, they are part of the Warden's kit. But for some reason only the regular locker prototype has binoculars in them, and not the hardsuit filled locker. This was certainly an oversight and not intentional.

## Technical details
<!-- Summary of code changes for easier review. -->
**Upstream Files**
Resources/Prototypes/Catalog/Fills/Lockers/security.yml -- Adds binoculars to the contents of LockerWardenFilledHardsuit
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/54c27ab9-1b47-4d45-b349-573fe29efb45)
Before
![image](https://github.com/user-attachments/assets/36fee20e-c8a9-4471-865b-33351677486a)
After

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
