### PR TITLE
Adds DMR ammo to ammo bundle

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -231,7 +231,8 @@ uplink-meds-bundle-name = Interdyne Medical Bundle
 uplink-meds-bundle-desc = An assortment of autoinjectors and premium medical equipment to cover for every possible situation. Contains an elite compact defibrillator that can be used as a weapon.
 
 uplink-ammo-bundle-name = Ammo Bundle
-uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, and 2 ammo boxes for the L6 SAW.
+uplink-ammo-bundle-desc = Reloading! Contains 4 magazines for the C-20r, 4 drums for the Bulldog, 2 ammo boxes for the L6 SAW, and 3 magazines for the Bandit.
+## Harmony change - changes ammo bundle uplink description
 
 uplink-sniper-bundle-name = Sniper Bundle
 uplink-sniper-bundle-desc = An inconspicuous briefcase that contains a Hristov, 10 spare bullets and a convenient disguise.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -116,7 +116,7 @@
   parent: ClothingBackpackDuffelSyndicateAmmo
   id: ClothingBackpackDuffelSyndicateAmmoFilled
   name: ammo bundle
-  description: "Reloading! Contains 4 magazines for the C-20r, 5 drums for the Bulldog, and 2 ammo boxes for the L6 SAW."
+  description: "Reloading! Contains 4 magazines for the C-20r, 5 drums for the Bulldog, 2 ammo boxes for the L6 SAW, and 3 magazines for the Bandit." # Harmony change - changes ammo bundle description
   components:
   - type: StorageFill
     contents:
@@ -128,6 +128,10 @@
         amount: 1
       - id: MagazineLightRifleBox
         amount: 2
+      # Begin harmony change - adds bandit mags to ammo bundle
+      - id: MagazineLightRifleCaseless
+        amount: 3
+      # End harmony change
 
 - type: entity
   parent: ClothingBackpackDuffelClown


### PR DESCRIPTION
## About the PR
slight oversight on my part when making the gun, forgot to add the mags to the ammo bundle

## Why / Balance
seems logical since nukies have to spend more TC otherwise

## Technical details
changes uplink-catalog.ftl with harmony comments
changes ammo bundle description and adds DMR magazines to ammo bundle fill prototype in duffelbag.yml in upstream namespace, adds harmony comment

## Media

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
