### PR TITLE
Adds announcement to inform of Extended rolling

### DIFF
--- a/Content.Server/StationEvents/Events/AlertLevelInterceptionRule.cs
+++ b/Content.Server/StationEvents/Events/AlertLevelInterceptionRule.cs
@@ -15,8 +15,8 @@ public sealed class AlertLevelInterceptionRule : StationEventSystem<AlertLevelIn
 
         if (!TryGetRandomStation(out var chosenStation))
             return;
-        if (_alertLevelSystem.GetLevel(chosenStation.Value) != "green")
-            return;
+//      if (_alertLevelSystem.GetLevel(chosenStation.Value) != "green") // harmony
+//          return;                                                     // harmony
 
         _alertLevelSystem.SetLevel(chosenStation.Value, component.AlertLevel, true, true, true);
     }

--- a/Content.Server/StationEvents/Events/AlertLevelInterceptionRule.cs
+++ b/Content.Server/StationEvents/Events/AlertLevelInterceptionRule.cs
@@ -15,8 +15,8 @@ public sealed class AlertLevelInterceptionRule : StationEventSystem<AlertLevelIn
 
         if (!TryGetRandomStation(out var chosenStation))
             return;
-//      if (_alertLevelSystem.GetLevel(chosenStation.Value) != "green") // harmony
-//          return;                                                     // harmony
+        if (_alertLevelSystem.GetLevel(chosenStation.Value) != "green")
+            return;
 
         _alertLevelSystem.SetLevel(chosenStation.Value, component.AlertLevel, true, true, true);
     }

--- a/Content.Server/_Harmony/StationEvents/Components/EmptyRuleComponent.cs
+++ b/Content.Server/_Harmony/StationEvents/Components/EmptyRuleComponent.cs
@@ -1,9 +1,6 @@
 using Content.Server._Harmony.StationEvents.Events;
-using Content.Server.StationEvents.Events;
 
 namespace Content.Server._Harmony.StationEvents.Components;
 
 [RegisterComponent, Access(typeof(EmptyRule))]
-public sealed partial class EmptyRuleComponent : Component
-{
-}
+public sealed partial class EmptyRuleComponent : Component;

--- a/Content.Server/_Harmony/StationEvents/Components/EmptyRuleComponent.cs
+++ b/Content.Server/_Harmony/StationEvents/Components/EmptyRuleComponent.cs
@@ -1,0 +1,9 @@
+using Content.Server._Harmony.StationEvents.Events;
+using Content.Server.StationEvents.Events;
+
+namespace Content.Server._Harmony.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(EmptyRule))]
+public sealed partial class EmptyRuleComponent : Component
+{
+}

--- a/Content.Server/_Harmony/StationEvents/Events/EmptyRule.cs
+++ b/Content.Server/_Harmony/StationEvents/Events/EmptyRule.cs
@@ -1,0 +1,13 @@
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+
+namespace Content.Server._Harmony.StationEvents.Events;
+
+public sealed class EmptyRule : StationEventSystem<Components.EmptyRuleComponent>
+{
+    protected override void Started(EntityUid uid, Components.EmptyRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+    }
+}

--- a/Content.Server/_Harmony/StationEvents/Events/EmptyRule.cs
+++ b/Content.Server/_Harmony/StationEvents/Events/EmptyRule.cs
@@ -1,13 +1,6 @@
-using Content.Server.StationEvents.Components;
+using Content.Server._Harmony.StationEvents.Components;
 using Content.Server.StationEvents.Events;
-using Content.Shared.GameTicking.Components;
 
 namespace Content.Server._Harmony.StationEvents.Events;
 
-public sealed class EmptyRule : StationEventSystem<Components.EmptyRuleComponent>
-{
-    protected override void Started(EntityUid uid, Components.EmptyRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
-    {
-        base.Started(uid, comp, gameRule, args);
-    }
-}
+public sealed class EmptyRule : StationEventSystem<EmptyRuleComponent>;

--- a/Resources/Locale/en-US/_Harmony/station-events/events/harmony-extended.ftl
+++ b/Resources/Locale/en-US/_Harmony/station-events/events/harmony-extended.ftl
@@ -1,0 +1,1 @@
+station-event-harmony-extended-announcement = Our long range scanners detect a significantly lower amount of threats in your sector.

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -113,3 +113,4 @@
       duration: 1500 # 3 mins
     - type: AlertLevelInterceptionRule
       alertLevel: green
+

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -94,9 +94,20 @@
     shoes: ClothingShoesBootsJack
     pocket1: MagazinePistol
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
     - WeaponPistolMk58
 #  storage: # can't put starting gear in backpack. works for nukies, not for DM.
 #    back:
 #      - MagazinePistol
 #      - MagazinePistol
+
+- type: entity
+  id: ExtendedHarmonyAnnouncement
+  parent: BaseStationEventShortDelay
+  components:
+    - type: StationEvent
+      endAnnouncement: station-event-harmony-extended-announcement
+      maxOccurrences: 1
+      duration: 180
+    - type: AlertLevelInterceptionRule
+      alertLevel: green

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -108,6 +108,8 @@
     - type: StationEvent
       endAnnouncement: station-event-harmony-extended-announcement
       maxOccurrences: 1
+      endAudio:
+        path: /Audio/Announcements/attention.ogg
       duration: 180
     - type: AlertLevelInterceptionRule
       alertLevel: green

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -94,7 +94,7 @@
     shoes: ClothingShoesBootsJack
     pocket1: MagazinePistol
     pocket2: MagazinePistol
-  inhand:
+  inhand: 
     - WeaponPistolMk58
 #  storage: # can't put starting gear in backpack. works for nukies, not for DM.
 #    back:

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -110,6 +110,6 @@
       maxOccurrences: 1
       endAudio:
         path: /Audio/Announcements/attention.ogg
-      duration: 180
+      duration: 1500 # 3 mins
     - type: AlertLevelInterceptionRule
       alertLevel: green

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -110,5 +110,5 @@
     maxOccurrences: 1
     endAudio:
       path: /Audio/Announcements/attention.ogg
-    duration: 3 # 25 mins
+    duration: 1500 # 25 mins
   - type: EmptyRule

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -105,11 +105,11 @@
   parent: BaseStationEventShortDelay
   id: ExtendedHarmonyAnnouncement
   components:
-    - type: StationEvent
-      endAnnouncement: station-event-harmony-extended-announcement
-      maxOccurrences: 1
-      endAudio:
-        path: /Audio/Announcements/attention.ogg
-      duration: 1500 # 3 mins
-    - type: AlertLevelInterceptionRule
-      alertLevel: green
+  - type: StationEvent
+    endAnnouncement: station-event-harmony-extended-announcement
+    maxOccurrences: 1
+    endAudio:
+      path: /Audio/Announcements/attention.ogg
+    duration: 1500 # 3 mins
+  - type: AlertLevelInterceptionRule
+    alertLevel: green

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -113,4 +113,3 @@
       duration: 1500 # 3 mins
     - type: AlertLevelInterceptionRule
       alertLevel: green
-

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -94,7 +94,7 @@
     shoes: ClothingShoesBootsJack
     pocket1: MagazinePistol
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
     - WeaponPistolMk58
 #  storage: # can't put starting gear in backpack. works for nukies, not for DM.
 #    back:
@@ -110,6 +110,6 @@
     maxOccurrences: 1
     endAudio:
       path: /Audio/Announcements/attention.ogg
-    duration: 1500 # 3 mins
+    duration: 1500 # 25 mins
   - type: AlertLevelInterceptionRule
     alertLevel: green

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -102,8 +102,8 @@
 #      - MagazinePistol
 
 - type: entity
-  id: ExtendedHarmonyAnnouncement
   parent: BaseStationEventShortDelay
+  id: ExtendedHarmonyAnnouncement
   components:
     - type: StationEvent
       endAnnouncement: station-event-harmony-extended-announcement

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -94,7 +94,7 @@
     shoes: ClothingShoesBootsJack
     pocket1: MagazinePistol
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
     - WeaponPistolMk58
 #  storage: # can't put starting gear in backpack. works for nukies, not for DM.
 #    back:
@@ -110,6 +110,5 @@
     maxOccurrences: 1
     endAudio:
       path: /Audio/Announcements/attention.ogg
-    duration: 1500 # 25 mins
-  - type: AlertLevelInterceptionRule
-    alertLevel: green
+    duration: 3 # 25 mins
+  - type: EmptyRule

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -83,6 +83,7 @@
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
+  - ExtendedHarmonyAnnouncement # harmony
 
 - type: gamePreset
   id: Greenshift


### PR DESCRIPTION
## About the PR
Adds an announcement to the extended preset which automatically plays after 25 minutes.

## Why / Balance

Discussion about this has been done to death about 100 times by now, so I am not going to write too much here as you can look it up in the following thread.
I will freely discuss things in the comments of this PR though.

Link to discussion:
https://discord.com/channels/1139716325627932682/1341424935788351630

To boil it down to a basic level, extended is in a state where some players feel as if the odds of extended rolling should be reduced while another would like to keep extended the way it is (generalizing here). This may or may not please both sides but it should serve to stem some frustration from players feeling like they've wasted their time or picked the wrong role for a greenshift.

## Technical details
added EmptyRule and EmptyRuleComponent in harmony namespace
added harmony extended announcement line in station-events in harmony namespace
added harmony announcement to Extended preset in game_presets.yml in upstream namespace, added harmony comment

## Media

![ext1](https://github.com/user-attachments/assets/5872378d-0953-446c-b106-c5eb9f7de1f3)

(In-game media later, but it is what it says on the tin)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added an announcement that plays when the Extended preset is selected.
