### PR TITLE
Remove DAGD from blood brothers

### DIFF
--- a/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
@@ -33,10 +33,6 @@
   id: BloodBrotherEscapeShuttleObjective
 
 - type: entity
-  parent: [BaseBloodBrotherObjective, DieObjective]
-  id: BloodBrotherDieObjective
-
-- type: entity
   parent: [BaseBloodBrotherObjective, TraitorSurviveObjective]
   id: BloodBrotherSurviveObjective
 

--- a/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
@@ -8,10 +8,9 @@
 - type: weightedRandom
   id: BloodBrotherObjectiveGroupState
   weights:
-    # Blood brothers are expected to be usually trying to be stealthy, so low DAGD chance.
-    BloodBrotherEscapeShuttleObjective: 0.25
-    BloodBrotherDieObjective: 0.10
-    BloodBrotherSurviveObjective: 0.65
+    # These should add up to 1
+    BloodBrotherEscapeShuttleObjective: 0.30
+    BloodBrotherSurviveObjective: 0.70
 
 # TODO: figure out how to make the converted brother holding the objective item also count towards the objective
 - type: weightedRandom


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removed the ability to roll the DAGD objective from blood brothers

The code in this PR is available under the MIT license.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It caused too many people to have DAGD when it rolled with a traitor too.

Requested by the admin team after a meeting.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Blood brothers can no longer roll the "Die A Glorious Death" objective.