### PR TITLE
Bingles No Longer Announce Their Presence

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/bingle/bingle.ftl
+++ b/Resources/Locale/en-US/_Goobstation/bingle/bingle.ftl
@@ -11,7 +11,8 @@ bingle-verb-2 = Mumbles
 bingle-verb-3 = Harks
 bingle-verb-4 = Grumbles
 
-bingle-station-announcement = Bingle Bingle Bingle
+#Harmony Change - comments out announcement to make bingles a silent antag spawn.
+#bingle-station-announcement = Bingle Bingle Bingle
 
 ghost-role-information-bingle-name = Bingle
 ghost-role-information-bingle-description = The Pit is love. The Pit is life. The Pit must grow

--- a/Resources/Prototypes/_Goobstation/Gamerules/bingleEvent.yml
+++ b/Resources/Prototypes/_Goobstation/Gamerules/bingleEvent.yml
@@ -3,7 +3,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    startAnnouncement: bingle-station-announcement
+    #startAnnouncement: bingle-station-announcement Harmony Change, removes announcement to make bingles a stealth spawn.
     duration: 50
     minimumPlayers: 15
   - type: RandomSpawnRule


### PR DESCRIPTION
## About the PR
Removes the Central Command annoucement that happens when AddGameRule BingleSpawn runs, and the bingle ghost role is spawned.

## Why / Balance
Very few antagonists announce their presence, especially ones that start as weak as a single bingle + its pit. Even major antagonists (non-ninja Dragons, Lone Ops, Wizards) either don't announce their presence, or its a choice for them via an announcement console. The announcement itself also felt not quite right for a MRP enviroment. A pole was ran to gauge interest in a new, more MRP-feeling message - but instead people suggested removing it to make the discovery of Bingles on station a bit more exciting.

This also gives other antags an excuse to be the boy who cried bingle, such as listening post faking a bingle callout that won't be meta'd by people seeing no CC announcement.

## Technical details
comments out the startAnnouncement field in Resources/Prototypes/_Goobstation/Gamerules/bingleEvent.yml
comments out the bingle-station-announcement string in Resources/Locale/En-US/bingle/bingle.ftl

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Bingles no longer announce their presence over the Central Command announcement console when they appear on station.


