### PR TITLE
Rework blood brother interactions with mindshields

### DIFF
--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Mind;
 using Content.Server.Popups;
 using Content.Server.Roles;
+using Content.Shared._Harmony.BloodBrothers.Components; // Harmony
 using Content.Shared.Database;
 using Content.Shared.Implants;
 using Content.Shared.Mindshield.Components;
@@ -43,7 +44,7 @@ public sealed class MindShieldSystem : EntitySystem
     /// </summary>
     private void MindShieldRemovalCheck(EntityUid implanted, EntityUid implant)
     {
-        if (HasComp<HeadRevolutionaryComponent>(implanted))
+        if (HasComp<HeadRevolutionaryComponent>(implanted) || HasComp<InitialBloodBrotherComponent>(implanted)) // Harmony - who doesn't love some good old hardcoded checks
         {
             _popupSystem.PopupEntity(Loc.GetString("head-rev-break-mindshield"), implanted);
             QueueDel(implant);

--- a/Content.Server/_Harmony/BloodBrothers/EntitySystems/BloodBrotherSystem.cs
+++ b/Content.Server/_Harmony/BloodBrothers/EntitySystems/BloodBrotherSystem.cs
@@ -1,5 +1,47 @@
-﻿using Content.Shared._Harmony.BloodBrothers.EntitySystems;
+﻿using Content.Server._Harmony.Objectives.Components;
+using Content.Server._Harmony.Roles;
+using Content.Server.Mind;
+using Content.Server.Roles;
+using Content.Shared._Harmony.BloodBrothers.Components;
+using Content.Shared._Harmony.BloodBrothers.EntitySystems;
 
 namespace Content.Server._Harmony.BloodBrothers.EntitySystems;
 
-public sealed class BloodBrotherSystem : SharedBloodBrotherSystem;
+public sealed class BloodBrotherSystem : SharedBloodBrotherSystem
+{
+    [Dependency] private readonly MindSystem _mindSystem = default!;
+    [Dependency] private readonly RoleSystem _roleSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BloodBrotherComponent, ComponentShutdown>(OnBloodBrotherShutdown);
+    }
+
+    private void OnBloodBrotherShutdown(Entity<BloodBrotherComponent> entity, ref ComponentShutdown args)
+    {
+        if (!_mindSystem.TryGetMind(entity, out var mindId, out var mind))
+            return;
+
+        if (_roleSystem.MindHasRole<BloodBrotherRoleComponent>(mindId))
+            _roleSystem.MindRemoveRole<BloodBrotherRoleComponent>(mindId);
+
+        int? objectiveToRemove = null;
+
+        var i = 0;
+        foreach (var objective in mind.Objectives)
+        {
+            if (HasComp<ConvertedBloodBrotherObjectiveComponent>(objective))
+            {
+                objectiveToRemove = i;
+                break;
+            }
+
+            i++;
+        }
+
+        if (objectiveToRemove != null)
+            _mindSystem.TryRemoveObjective(mindId, mind, objectiveToRemove.Value);
+    }
+}

--- a/Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs
+++ b/Content.Server/_Harmony/GameTicking/Rules/BloodBrotherRuleSystem.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Content.Server._Harmony.GameTicking.Rules.Components;
 using Content.Server._Harmony.Roles;
+using Content.Server.Actions;
 using Content.Server.Administration.Logs;
 using Content.Server.Antag;
 using Content.Server.GameTicking.Rules;
@@ -34,6 +35,7 @@ public sealed class BloodBrotherRuleSystem : GameRuleSystem<BloodBrotherRuleComp
     [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IServerPreferencesManager _preferencesManager = default!;
+    [Dependency] private readonly ActionsSystem _actionsSystem = default!;
     [Dependency] private readonly AntagSelectionSystem _antagSystem = default!;
     [Dependency] private readonly MindSystem _mindSystem = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
@@ -165,9 +167,11 @@ public sealed class BloodBrotherRuleSystem : GameRuleSystem<BloodBrotherRuleComp
         if (entity.Comp.ConvertStunTime != null)
             _stunSystem.TryParalyze(args.Target, entity.Comp.ConvertStunTime.Value, true);
 
-        // Cleanup the data
-        RemCompDeferred<InitialBloodBrotherComponent>(entity);
+        // Remove the conversion actions
+        _actionsSystem.RemoveAction(entity.Comp.ConvertActionEntity);
+        _actionsSystem.RemoveAction(entity.Comp.CheckConvertActionEntity);
 
+        // Make sure the components are sent correctly
         Dirty(entity, originalComponent);
         Dirty(args.Target, convertedComp);
     }

--- a/Content.Server/_Harmony/Objectives/Components/ConvertedBloodBrotherObjectiveComponent.cs
+++ b/Content.Server/_Harmony/Objectives/Components/ConvertedBloodBrotherObjectiveComponent.cs
@@ -1,0 +1,9 @@
+using Content.Server._Harmony.BloodBrothers.EntitySystems;
+
+namespace Content.Server._Harmony.Objectives.Components;
+
+/// <summary>
+/// Marker component to show that an objective should be removed when the blood brother is deconverted.
+/// </summary>
+[RegisterComponent, Access(typeof(BloodBrotherSystem))]
+public sealed partial class ConvertedBloodBrotherObjectiveComponent : Component;

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Harmony.BloodBrothers.EntitySystems; // Harmony
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
@@ -11,6 +12,7 @@ namespace Content.Shared.Revolutionary;
 
 public abstract class SharedRevolutionarySystem : EntitySystem
 {
+    [Dependency] private readonly SharedBloodBrotherSystem _bloodBrotherSystem = default!; // Harmony
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStunSystem _sharedStun = default!;
 
@@ -45,6 +47,8 @@ public abstract class SharedRevolutionarySystem : EntitySystem
             _sharedStun.TryParalyze(uid, stunTime, true);
             _popupSystem.PopupEntity(Loc.GetString("rev-break-control", ("name", name)), uid);
         }
+
+        _bloodBrotherSystem.OnBloodBrotherMindshielded((uid, comp), ref init); // Harmony (who doesn't love some good old hardcoding)
     }
 
     /// <summary>

--- a/Content.Shared/_Harmony/BloodBrothers/Components/BloodBrotherComponent.cs
+++ b/Content.Shared/_Harmony/BloodBrothers/Components/BloodBrotherComponent.cs
@@ -14,5 +14,8 @@ public sealed partial class BloodBrotherComponent : Component
     [DataField]
     public ProtoId<FactionIconPrototype> BloodBrotherIcon = "BloodBrotherFaction";
 
+    [DataField]
+    public TimeSpan? DeconversionStunTime = TimeSpan.FromSeconds(3);
+
     public override bool SessionSpecific => true;
 }

--- a/Content.Shared/_Harmony/BloodBrothers/EntitySystems/SharedBloodBrotherSystem.cs
+++ b/Content.Shared/_Harmony/BloodBrothers/EntitySystems/SharedBloodBrotherSystem.cs
@@ -1,6 +1,10 @@
 ﻿using Content.Shared._Harmony.BloodBrothers.Components;
 using Content.Shared.Actions;
 using Content.Shared.Antag;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Mindshield.Components;
+using Content.Shared.Popups;
+using Content.Shared.Stunnable;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 
@@ -9,6 +13,8 @@ namespace Content.Shared._Harmony.BloodBrothers.EntitySystems;
 public abstract class SharedBloodBrotherSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedStunSystem _stunSystem = default!;
 
     public override void Initialize()
     {
@@ -37,6 +43,27 @@ public abstract class SharedBloodBrotherSystem : EntitySystem
         ref ComponentGetStateAttemptEvent args)
     {
         args.Cancelled = !CanGetState(args.Player);
+    }
+
+    public void OnBloodBrotherMindshielded(Entity<MindShieldComponent> entity, ref MapInitEvent args)
+    {
+        if (HasComp<InitialBloodBrotherComponent>(entity))
+        {
+            RemCompDeferred<MindShieldComponent>(entity);
+            return;
+        }
+
+        if (TryComp<BloodBrotherComponent>(entity, out var bloodBrother))
+        {
+            var name = Identity.Entity(entity, EntityManager);
+            RemCompDeferred<BloodBrotherComponent>(entity);
+            if (bloodBrother.DeconversionStunTime != null)
+                _stunSystem.TryParalyze(entity, bloodBrother.DeconversionStunTime.Value, true);
+            _popupSystem.PopupEntity(
+                Loc.GetString("blood-brother-break-control", ("name", name)),
+                entity,
+                PopupType.MediumCaution);
+        }
     }
 
     private bool CanGetState(ICommonSession? player)

--- a/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-bloodbrother.ftl
+++ b/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-bloodbrother.ftl
@@ -16,6 +16,8 @@ blood-brother-role-greeting =
 
 blood-brother-briefing = Collaborate with your blood brother to accomplish all your objectives.
 
+blood-brother-break-control = {CAPITALIZE(THE($name))} has remembered their true allegiance!
+
 # Conversion
 
 blood-brother-convert-failed-no-mind = {CAPITALIZE(THE($converted))} does not have a mind

--- a/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
@@ -25,6 +25,7 @@
   - type: TargetObjective
     title: objective-condition-blood-brother-progress-title
   - type: HelpProgressCondition
+  - type: ConvertedBloodBrotherObjective
 
 # state
 


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Initial blood brothers will now break the mindshield when getting mindshielded.
Converted blood brothers will be deconverted when they are mindshielded.

This pull request requires a change to the "Refusal of Mindshielding" law.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Decided by the admins during a meeting:

> There have been multiple instances of people removing their mindshields intentionally as a head, and multiple instances of heads sandbagging to get converted. This stems from how it's possible to remove a head's mindshield and then put it back on. Easiest solution would be to just remove the ability to remove mindshields or to make it so you cannot put your mindshield back on as a convertee without losing your antag status.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/2e6cc118-3ee1-4900-a321-799851fea90a


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Blood brothers are now incompatible with mindshields.