### PR TITLE
Random Hardsuit Suit Locker (For mapping as salv loot)

### DIFF
--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml
@@ -74,12 +74,12 @@
     # Suits (Common)
     - !type:GroupSelector
       children:
-      - id: ClothingOuterHarduitPirateEVA
+      - id: ClothingOuterHardsuitPirateEVA
       - !type:AllSelector
         children:
           - id: ClothingOuterHardsuitSpatio
-        - id: MaterialCloth10
-        - id: SheetPlastic10
+          - id: MaterialCloth10
+          - id: SheetPlastic10
     # Tanks (Common)
     - !type:GroupSelector
       children:
@@ -110,8 +110,10 @@
     # Suits (Rare)
     - !type:GroupSelector
       children:
-      - id: ClothingOuterHardsuitMime
-      - id: ClothingOuterHardsuitClown
+      - !type:GroupSelector
+        children:
+          - id: ClothingOuterHardsuitMime
+          - id: ClothingOuterHardsuitClown
       - id: ClothingOuterHardsuitPirateCap
       - id: ClothingOuterHardsuitSalvage
     # Tanks (Rare)
@@ -152,6 +154,7 @@
         - id: JetpackVoidFilled
         - id: ClothingHeadHelmetAncient
         - id: ClothingOuterHardsuitAncientEVA
+        - id: AirTankFilled
       - !type:AllSelector
         children:
         # Suits (Legendary)
@@ -187,5 +190,17 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
-        tableId: SuitStorageSalvLootTableBasic
+      entity_storage: !type:GroupSelector
+        children:
+        - !type:NestedSelector
+          weight: 30
+          tableId: SuitStorageSalvLootTableBasic
+        - !type:NestedSelector
+          weight: 40
+          tableId: SuitStorageSalvLootTableCommon
+        - !type:NestedSelector
+          weight: 25
+          tableId: SuitStorageSalvLootTableRare
+        - !type:NestedSelector
+          weight: 5
+          tableId: SuitStorageSalvLootTableLegendary

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml
@@ -149,7 +149,7 @@
       children:
       # NTSRA + Voidpack
       - !type:AllSelector
-        weight: 0.5
+        weight: 0.2
         children:
         - id: JetpackVoidFilled
         - id: ClothingHeadHelmetAncient

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml
@@ -1,0 +1,191 @@
+# Lockers for salvage grids such as Ruins and Wrecks or for spawner tables for them
+
+# Suit Storage Unit Tables
+
+# Tank Tables
+
+## Big Tanks
+- type: entityTable
+  id: BigTankFilledTable
+  table: !type:GroupSelector
+    children:
+    - id: AirTankFilled
+    - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+
+## Emergency Tanks
+- type: entityTable
+  id: EmergencyTankFilledTable
+  table: !type:GroupSelector
+    children:
+    - id: EmergencyOxygenTankFilled
+    - id: EmergencyNitrogenTankFilled
+    - id: EmergencyFunnyOxygenTankFilled
+
+## Extended Tanks
+- type: entityTable
+  id: ExtendedTankFilledTable
+  table: !type:GroupSelector
+    children:
+    - id: ExtendedEmergencyOxygenTankFilled
+    - id: ExtendedEmergencyNitrogenTankFilled
+
+## Double Emergency Tanks
+- type: entityTable
+  id: DoubleEmergencyTankFilledTable
+  table: !type:GroupSelector
+    children:
+    - id: DoubleEmergencyOxygenTankFilled
+    - id: DoubleEmergencyNitrogenTankFilled
+
+## Suits Table
+- type: entityTable
+  id: SuitStorageSalvLootTableBasic
+  table: !type:AllSelector
+    children:
+    # Basic
+    - id: ClothingMaskBreath
+    # Suits (Basic)
+    - !type:GroupSelector
+      children:
+      # Emergency EVA
+      - id: ClothingOuterSuitEmergency
+      # EVA
+      - !type:AllSelector
+        children:
+        - id: ClothingOuterHardsuitEVA
+        # EVA Helmet
+        - !type:GroupSelector
+          children:
+          - id: ClothingHeadHelmetEVA
+          - id: ClothingHeadHelmetEVALarge
+    # Tanks (Basic)
+    - !type:GroupSelector
+      children:
+      - !type:NestedSelector
+        tableId: BigTankFilledTable
+      - !type:NestedSelector
+        tableId: EmergencyTankFilledTable
+
+- type: entityTable
+  id: SuitStorageSalvLootTableCommon
+  table: !type:AllSelector
+    children:
+    # Suits (Common)
+    - !type:GroupSelector
+      children:
+      - id: ClothingOuterHarduitPirateEVA
+      - !type:AllSelector
+        children:
+          - id: ClothingOuterHardsuitSpatio
+        - id: MaterialCloth10
+        - id: SheetPlastic10
+    # Tanks (Common)
+    - !type:GroupSelector
+      children:
+      - !type:NestedSelector
+        tableId: BigTankFilledTable
+        weight: 2
+      - !type:NestedSelector
+        tableId: EmergencyTankFilledTable
+      - !type:NestedSelector
+        tableId: ExtendedTankFilledTable
+    # Jetpacks (Common)
+    - !type:GroupSelector
+      children:
+      - id: ScrapJetpack
+        weight: 2
+      - id: JetpackMiniFilled
+    # Masks (Common)
+    - !type:GroupSelector
+      children:
+      - id: ClothingMaskBreath
+      - id: ClothingMaskBreathMedicalSecurity
+      - id: ClothingMaskGas
+
+- type: entityTable
+  id: SuitStorageSalvLootTableRare
+  table: !type:AllSelector
+    children:
+    # Suits (Rare)
+    - !type:GroupSelector
+      children:
+      - id: ClothingOuterHardsuitMime
+      - id: ClothingOuterHardsuitClown
+      - id: ClothingOuterHardsuitPirateCap
+      - id: ClothingOuterHardsuitSalvage
+    # Tanks (Rare)
+    - !type:GroupSelector
+      children:
+      - !type:NestedSelector
+        tableId: BigTankFilledTable
+      - !type:NestedSelector
+        tableId: ExtendedTankFilledTable
+      - !type:NestedSelector
+        tableId: DoubleEmergencyTankFilledTable
+    # Jetpacks (Rare)
+    - !type:GroupSelector
+      children:
+      - id: ScrapJetpack
+      - id: JetpackMiniFilled
+      - id: JetpackBlueFilled
+      - id: JetpackVoidFilled
+        weight: 0.5
+    # Masks (Rare)
+    - !type:GroupSelector
+      children:
+      - id: ClothingMaskGasExplorer
+      - id: ClothingMaskGas
+      - id: ClothingMaskBreathMedicalSecurity
+
+- type: entityTable
+  id: SuitStorageSalvLootTableLegendary
+  table: !type:AllSelector
+    children:
+    - id: ClothingMaskGasMerc
+    - !type:GroupSelector
+      children:
+      # NTSRA + Voidpack
+      - !type:AllSelector
+        weight: 0.5
+        children:
+        - id: JetpackVoidFilled
+        - id: ClothingHeadHelmetAncient
+        - id: ClothingOuterHardsuitAncientEVA
+      - !type:AllSelector
+        children:
+        # Suits (Legendary)
+        - !type:GroupSelector
+          children:
+          - id: ClothingOuterHardsuitLuxury
+          - !type:AllSelector
+            children:
+            - id: ClothingOuterEVASuitSyndicate
+            - id: ClothingHeadHelmetSyndicate
+          - id: ClothingOuterHardsuitBrigmedic # Dripped out suit that only spawns on the visitor shuttle
+          - id: ClothingOuterSuitCarp # Not the hardsuit one, just for drip
+          - id: ClothingOuterHardsuitLing # Creepy...
+        # Tanks (Legendary)
+        - !type:GroupSelector
+          children:
+          - !type:NestedSelector
+            tableId: ExtendedTankFilledTable
+          - !type:NestedSelector
+            tableId: DoubleEmergencyTankFilledTable
+        # Jetpacks (Legendary)
+        - !type:GroupSelector
+          children:
+          - id: JetpackVoidFilled
+          - id: JetpackBlueFilled
+            weight: 0.5
+
+# Random Suit Storage Locker
+- type: entity
+  id: HarmonySuitStorageRandomSalvLoot
+  parent: SuitStorageBase
+  suffix: Filled, Random, Salvage, Harmony
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: SuitStorageSalvLootTableBasic


### PR DESCRIPTION
## About the PR
Adds a new Random Suit Storage Unit, inteded for looting by salvage on Ruins, Wrecks, and other such Grids.

## Why / Balance
I was making maps, and went "huh I wish I could spawn a suit storage locker filled with random hardsuits" enough times, so I made it.

The suit storage table selector is split into tiers, laid out like so
![image](https://github.com/user-attachments/assets/de47f6d8-c8cc-43e2-8e4c-f0e217399a42)

Each tier spawns a random hardsuit, a random airtank, a random breath mask, and a random jetpack. Most of the time, the suit will be decorational as it won't be worth grabbing over the spationaut suit salvage spawns with or a Goliath Hardsuit if that is made.
Instead, these are inteded as decor and to help the station in situations EVA needs to be opened, or to help regear any salvs that may have lost their suit somehow.

![Screenshot 2025-07-09 060214](https://github.com/user-attachments/assets/a60da462-5aac-4dfc-ad02-dae6bf5ec80a)

While the suits and breath masks may not be useful, the air tanks and jetpacks probably will be.
The spationaut spawning with cloth and plastic will hopefully push newer salvs to discover the Goliath Hardsuit upgrade system.

## Technical details
Creates Resources/Prototypes/_Harmony/Catalog/Fills/Lockers/salvage_grids.yml

Adds the following Table entities to it:
BigTankFilledTable, EmergencyTankFilledTable, ExtendedTankFilledTable, DoubleEmergencyTankFilledTable (These were made so that the category could be rolled and to reduce unnecessary repetition)

SuitStorageSalvLootTableBasic, SuitStorageSalvLootTableCommon, SuitStorageSalvLootTableRare, SuitStorageSalvLootTableLegendary

Adds HarmonySuitStorageRandomSalvLoot, a Suit Storage Locker that pulls from the SuitStorageSalvLootTables.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
This will Probably merge conflict with my other salv loot locker and spawner PRs. I'll fix them if that happens.

_Changes are not player facing._
