### PR TITLE
nerfs hushpup

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -18,5 +18,7 @@
       path: /Audio/_Harmony/Weapons/Guns/Gunshots/hushpup_fire.ogg
       params:
         volume: -3
-    fireRate: 2
+    fireRate: 1.5
     selectedMode: SemiAuto
+  - type: GunSpreadModifier
+    spread: 1.4


### PR DESCRIPTION
## About the PR
lowers hushpup firerate to 1.5
makes hushpup spread 40% higher

## Why / Balance
admins have let me know the hushpup is too much of a must buy, so i will be doing something about it

i wanted to keep the hushpup at the same price while making it less of a must buy for traitors, now you HAVE to barrel stuff people with it to instantly kill them, and it should be more punishing to miss your shots.

if this isnt enough then i will probably nerf it AGAIN or increase the price and revert the buff.

## Technical details
changes to weapons/guns/shotguns/shotguns.yml in harmony namespace

## Media
media soon

## Requirements
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Nerfed hushpup firerate and spread
