### PR TITLE
fixes wrong lecter sprite on request computer

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -83,7 +83,7 @@
 - type: cargoProduct
   id: ArmoryRifle
   icon:
-    sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
+    sprite: _Harmony/Objects/Weapons/Guns/Rifles/lecter.rsi
     state: icon
   product: CrateArmoryRifle
   cost: 8000

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -83,7 +83,7 @@
 - type: cargoProduct
   id: ArmoryRifle
   icon:
-    sprite: _Harmony/Objects/Weapons/Guns/Rifles/lecter.rsi
+    sprite: _Harmony/Objects/Weapons/Guns/Rifles/lecter.rsi # Harmony - changed sprite path
     state: icon
   product: CrateArmoryRifle
   cost: 8000


### PR DESCRIPTION
## About the PR
fixes incorrect sprite path, now the rifle crate uses our lecter sprite

## Why / Balance
wrong lecter sprite

## Technical details
Changed sprite path in cargo_armory.yml in upstream namespace, added harmony comment

## Media

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Fixed upstream lecter sprite appearing in the rifle crate order