### PR TITLE
removes Estoc DMR from uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -198,19 +198,21 @@
   categories:
   - UplinkWeaponry
 
-- type: listing
-  id: UplinkEstocBundle
-  name: uplink-estoc-bundle-name
-  description: uplink-estoc-bundle-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateFilledRifle
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 11
-  cost:
-    Telecrystal: 18
-  categories:
-  - UplinkWeaponry
+# Start Harmony Change : removes Estoc DMR from uplink
+#- type: listing
+#  id: UplinkEstocBundle
+#  name: uplink-estoc-bundle-name
+#  description: uplink-estoc-bundle-desc
+#  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
+#  productEntity: ClothingBackpackDuffelSyndicateFilledRifle
+#  discountCategory: veryRareDiscounts
+#  discountDownTo:
+#    Telecrystal: 11
+#  cost:
+#    Telecrystal: 18
+#  categories:
+#  - UplinkWeaponry
+# End harmony change
 
 - type: listing
   id: UplinkBulldogBundle


### PR DESCRIPTION
## About the PR
removes Estoc DMR from nukie and traitor uplinks

## Why / Balance
It's bloat since we currently have two DMR options and some admins have voiced their opinion that they would rather have our homemade DMR instead of the upstream one.

## Technical details
comments out uplink option in uplink_catalog.yml in harmony namespace adds harmony comments

## Media
picture an uplink without the estoc in it

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- remove: Removed the Estoc DMR from the uplink