### PR TITLE
Fixes pizza bomb description

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -11,7 +11,7 @@ uplink-rifle-bandit-desc = Contains the Bandit, a reliable semi-auto bullpup whi
 
 # Explosive
 
-uplink-pizza-bomb-name = Nefarious Pizza Bomb
+uplink-pizza-bomb-name = Pizza Bomb
 uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the Syndicate for eliminating high value targets. WARNING: Opens after exploding with a short timer. Do not attempt to throw.
 
 uplink-pizza-bomb-surplus-name = Surplus Pizza Bomb

--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -11,8 +11,8 @@ uplink-rifle-bandit-desc = Contains the Bandit, a reliable semi-auto bullpup whi
 
 # Explosive
 
-uplink-pizza-bomb-name = Nefarious Pizza bomb
-uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the syndicate for eliminating high value targets
+uplink-pizza-bomb-name = Nefarious Pizza Bomb
+uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the Syndicate for eliminating high value targets. WARNING: Short timer. Do not attempt to throw.
 
 uplink-pizza-bomb-surplus-name = Surplus Pizza Bomb
 uplink-pizza--surplus-desc = This shouldn't be visible, report me.

--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -12,7 +12,7 @@ uplink-rifle-bandit-desc = Contains the Bandit, a reliable semi-auto bullpup whi
 # Explosive
 
 uplink-pizza-bomb-name = Nefarious Pizza Bomb
-uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the Syndicate for eliminating high value targets. WARNING: Short timer. Do not attempt to throw.
+uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the Syndicate for eliminating high value targets. WARNING: Opens after exploding with a short timer. Do not attempt to throw.
 
 uplink-pizza-bomb-surplus-name = Surplus Pizza Bomb
 uplink-pizza--surplus-desc = This shouldn't be visible, report me.

--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -12,7 +12,7 @@ uplink-rifle-bandit-desc = Contains the Bandit, a reliable semi-auto bullpup whi
 # Explosive
 
 uplink-pizza-bomb-name = Pizza Bomb
-uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the Syndicate for eliminating high value targets. WARNING: Opens after exploding with a short timer. Do not attempt to throw.
+uplink-pizza-bomb-desc = This tech, first pioneered by terrorists, now is used by the Syndicate for eliminating high value targets. WARNING: Explodes after opening with a short timer. Do not attempt to throw.
 
 uplink-pizza-bomb-surplus-name = Surplus Pizza Bomb
 uplink-pizza--surplus-desc = This shouldn't be visible, report me.


### PR DESCRIPTION
## About the PR
fixes grammar in pizza bomb description and clarifies that it is infact not a grenade

## Why / Balance
pizza bomb got changed a while ago to no longer be throwable and explodes almost instantly upon opening, this should probably be clarified so people dont kill themselves with it

also fixes grammar because it never got touched for some reason?

## Technical details
changes uplink-catalog.ftl in harmony namespace

## Media
<img width="381" height="151" alt="obraz" src="https://github.com/user-attachments/assets/9b6653ed-8f82-4629-aa2d-4f4c10bd4adb" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Tweaked pizza box description to be less ambiguous