### PR TITLE
Salvage Mining Hardsuit Speed Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -162,8 +162,8 @@
   - type: ClothingSpeedModifier
 #    walkModifier: 0.75
 #    sprintModifier: 0.75
-    walkModifier: 0.70
-    sprintModifier: 0.70
+    walkModifier: 0.80
+    sprintModifier: 0.80
 # End of Harmony Change
   - type: HeldSpeedModifier
   - type: ToggleableClothing


### PR DESCRIPTION
## About the PR
Reduces the Salvage Mining Hardsuit's speed slowdown from 30% to 20%, [in response to community feedback.](https://discord.com/channels/1139716325627932682/1307942320108208170/1387879485411426497)

## Why / Balance
As part of a wider salvage hardsuit balance in PR , the mining hardsuit's slowdown was brought up from 25% to 30%.
However, as most folks know, speed is a very important stat in the game. with slow hardsuits either being intended for complete non-combatants or having very high resistances.

Now, the mining suit sits in the awkward placement of too slow for combat but not protective enough for combat either, despite Salvage being a PvE-focused (and thus combat-focused) job. A 30% slowdown is equivalent to Engineering hardsuits, and often Engi's will resort to dragging a locker with their hardsuit around instead of wearing it, a trait not ideal for a Salvage hardsuit.

Also, when placed in context that the spationaut and goliath hardsuits had their slowdown moved from 20% to 15%, the increase in the mining suits slowdown without the stats to compensate feels out of place. As it stands, the mining suit is not the Tier 2 Salvage Suit it is intended to be - instead of people wearing it over the spationaut, its often ignored even when found.

Moving the mining suits speed from 30% to 20% matches closer the pattern of the other suits, being 5% faster than before the balance pass while having their strongest brute resistance applied to blunt and slash, with pierce lagging around 20% behind.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: the salvage mining hardsuit is now faster.
