### PR TITLE
Digiboard Can Now Link To Telepads

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -311,3 +311,14 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: BoxFolderQmClipboard
+  #Start of Harmony Change
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSource
+    range: 200
+    ports:
+    - OrderSender
+  #End of Harmony Change


### PR DESCRIPTION
## About the PR
The Quartermaster's digiboard can now be linked to telepads, just like regular order consoles.
Code ported from https://github.com/moff-station/moff-station-14/pull/110 but was moved to the appropriate file due to changes between forks.

## Why / Balance
-Allows the QM to use their digiboard as a full replacement for the order consoles, as its intended to be, even when the cargo telepads are added.
-Stops feels-bad moments where a QM orders items without thinking and it goes to the ATS, which might be destroyed or otherwise inaccessible.
-Honestly, i'm surprised it wasin't designed this way originally or it hasn't been added yet. It was a quick change. Why not make it consistent?

## Technical details
-Adds a block of code to Resources/Prototypes/Entities/Objects/Misc/Folders.yml.

## Media
[compressed_mediaforpr.webm](https://github.com/user-attachments/assets/215de58b-e967-4f41-8046-1dfd1d7c6b95)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: The QM's digiboard can now link to Cargo Order Consoles. Gambling has never been easier.
