### PR TITLE
Bingle Bongle, changed the raffle times from 30 seconds to 10

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
@@ -9,7 +9,7 @@
     description: ghost-role-information-bingle-description
     rules: ghost-role-information-bingle-rules
     raffle:
-      settings: default
+      settings: short #Harmony Change from default
     mindRoles:
     - MindRoleGhostRoleTeamAntagonist
   - type: GhostRoleMobSpawner

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -10,7 +10,7 @@
     description: ghost-role-information-bingle-description
     rules: ghost-role-information-bingle-rules
     raffle:
-      settings: default
+      settings: short #Harmony Change from default
     mindRoles:
     - MindRoleGhostRoleTeamAntagonist
   - type: Sprite


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Changed Bingle raffle time from 30 seconds to 10 seconds
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This will allow ghost players to better utilize the number of bingle ghost roles generated by the bingle hole, giving them a chance to respawn after death as most of the time security can clear the hole in the 30 seconds
## Technical details
<!-- Summary of code changes for easier review. -->
Changed the raffle time from default to short in the YAML files for bingles

## Media

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Changed bingle raffle times from 30 seconds to 10 seconds