### PR TITLE
Missing section of code for trinket.yml

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -28,6 +28,14 @@
     back:
     - ClothingMultipleHeadphones
 
+# Harmony Change Start: CardsPort
+- type: loadout
+  id: CardBoxBlack
+  storage:
+    back:
+    - CardBoxBlack
+# End Harmony Change
+
 # Toys
 - type: loadout
   id: PlushieLizard


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
For some reason trinket.yml is missing the piece of code that allows someone to pick a cardbox as a trinket item, which is weird because it's in the pr... either way, this should fix it
## Technical details
<!-- Summary of code changes for easier review. -->
Just edited trinket.yml to include the cardbox

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Card boxes now show up as a trinket!