### PR TITLE
Ports "Chemmaster pill buffer change" from DeltaV

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -81,7 +81,7 @@
             <BoxContainer Orientation="Horizontal">
                 <Label Text="{Loc 'chem-master-window-packaging-text'}" />
                 <Control HorizontalExpand="True"/>
-                <Label Text="{Loc 'chem-master-window-buffer-label'}" />
+                <Label Text="{Loc 'chem-master-window-container-label'}" /> <!-- DeltaV-->
                 <Label Name="BufferCurrentVolume" StyleClasses="LabelSecondaryColor" />
             </BoxContainer>
 

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -150,7 +150,7 @@ namespace Content.Client.Chemistry.UI
             // Ensure the Panel Info is updated, including UI elements for Buffer Volume, Output Container and so on
             UpdatePanelInfo(castState);
 
-            BufferCurrentVolume.Text = $" {castState.BufferCurrentVolume?.Int() ?? 0}u";
+            BufferCurrentVolume.Text = $" {castState.InputContainerInfo?.CurrentVolume.Int() ?? 0}u"; // DeltaV
 
             InputEjectButton.Disabled = castState.InputContainerInfo is null;
             OutputEjectButton.Disabled = castState.OutputContainerInfo is null;

--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -277,10 +277,19 @@ namespace Content.Server.Chemistry.EntitySystems
         {
             outputSolution = null;
 
-            if (!_solutionContainerSystem.TryGetSolution(chemMaster.Owner, SharedChemMaster.BufferSolutionName, out _, out var solution))
+            // Harmony Change Start - ChemMasters make pills from containers and not the buffer
+            // if (!_solutionContainerSystem.TryGetSolution(chemMaster.Owner, SharedChemMaster.BufferSolutionName, out _, out var solution))
+            // {
+            //     return false;
+            // }
+
+            var container = _itemSlotsSystem.GetItemOrNull(chemMaster, SharedChemMaster.InputSlotName);
+            if (container is null ||
+                !_solutionContainerSystem.TryGetFitsInDispenser(container.Value, out var containerSoln, out var solution))
             {
                 return false;
             }
+            // Harmony Change End
 
             if (solution.Volume == 0)
             {
@@ -298,6 +307,7 @@ namespace Content.Server.Chemistry.EntitySystems
             }
 
             outputSolution = solution.SplitSolution(neededVolume);
+            _solutionContainerSystem.UpdateChemicals(containerSoln.Value); // DeltaV
             return true;
         }
 


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Ports https://github.com/DeltaV-Station/Delta-v/pull/3329, which changes the ChemMaster 4000 to create pills from chems loaded into the Container instead of Buffer.

## Why / Balance
This feature is often requested, and the concept of porting it was met with much enthusiasm from Harmony's medical playerbase.

As it currently stands, to create specific pills you have to have an empty ChemMaster that you can use to load stuff into the buffer. This only really happens if not all chemist slots are filled, because most chemists utilize the ChemMaster & its buffer to create all their chems.

By making the pills take from the container slot instead, not only is it more intuitive (new chemists often make the mistake of thinking that it Is the slot for making pills) but it is more versatile.

Opening up pills to be easier to make allows for greater RP, with prescription pills being makeable, as well as an easier route to pre-existing but rarely used avenues of chems in combat and other mechanical situations.

## Technical details
Content.Client/Chemistry/UI/ChemMasterWindow.xaml - Modified the Packaging section to use the container slot info instead of the buffer slot info

Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs - Modified the Pill section to use the container slot info instead of the buffer slot info

Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs - Modified the code that takes the chems to put into pills to use the container slot info instead of the buffer slot info

## Media

<img width="633" height="864" alt="Screenshot 2025-08-03 205939" src="https://github.com/user-attachments/assets/561cbe68-126a-439a-b199-31ca0a8e0a9b" />

<img width="568" height="685" alt="Screenshot 2025-08-03 210034" src="https://github.com/user-attachments/assets/1f7ef0d8-1d5e-454c-81e1-687e5253e068" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**
:cl:
- tweak: The ChemMaster 4000 now uses the chemicals in the beaker to make pills, instead of the ones from the buffer.


