### PR TITLE
Guidebook entry for Avali

### DIFF
--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -52,9 +52,3 @@
   id: Vox
   name: species-name-vox
   text: "/ServerInfo/Guidebook/Mobs/Vox.xml"
-
-# Harmony species
-- type: guideEntry
-  id: Avali
-  name: species-name-avali
-  text: "/ServerInfo/_Harmony/Guidebook/Mobs/Avali.xml"

--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -53,9 +53,8 @@
   name: species-name-vox
   text: "/ServerInfo/Guidebook/Mobs/Vox.xml"
 
-# Harmony change start
+# Harmony species
 - type: guideEntry
   id: Avali
   name: species-name-avali
   text: "/ServerInfo/_Harmony/Guidebook/Mobs/Avali.xml"
-# Harmony change end

--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -11,6 +11,7 @@
     - Reptilian
     - SlimePerson
     - Vox
+    - Avali # harmony
 
 - type: guideEntry
   id: Arachnid
@@ -51,3 +52,10 @@
   id: Vox
   name: species-name-vox
   text: "/ServerInfo/Guidebook/Mobs/Vox.xml"
+
+# Harmony change start
+- type: guideEntry
+  id: Avali
+  name: species-name-avali
+  text: "/ServerInfo/_Harmony/Guidebook/Mobs/Avali.xml"
+# Harmony change end

--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -4,6 +4,7 @@
   text: "/ServerInfo/Guidebook/Mobs/Species.xml"
   children:
     - Arachnid
+    - Avali # harmony
     - Diona
     - Dwarf
     - Human
@@ -11,7 +12,6 @@
     - Reptilian
     - SlimePerson
     - Vox
-    - Avali # harmony
 
 - type: guideEntry
   id: Arachnid

--- a/Resources/Prototypes/_Harmony/Guidebook/species.yml
+++ b/Resources/Prototypes/_Harmony/Guidebook/species.yml
@@ -1,0 +1,4 @@
+- type: guideEntry
+  id: Avali
+  name: species-name-avali
+  text: "/ServerInfo/_Harmony/Guidebook/Mobs/Avali.xml"

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -14,6 +14,7 @@
   <GuideEntityEmbed Entity="MobReptilian" Caption="Reptilian"/>
   <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
+  <GuideEntityEmbed Entity="MobAvali" Caption="Avali"/> <!--harmony-->
   </Box>
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -5,6 +5,7 @@
 
   <Box>
   <GuideEntityEmbed Entity="MobArachnid" Caption="Arachnid"/>
+  <GuideEntityEmbed Entity="MobAvali" Caption="Avali"/> <!--harmony-->
   <GuideEntityEmbed Entity="MobDiona" Caption="Diona"/>
   <GuideEntityEmbed Entity="MobDwarf" Caption="Dwarf"/>
   <GuideEntityEmbed Entity="MobHuman" Caption="Human"/>
@@ -14,7 +15,6 @@
   <GuideEntityEmbed Entity="MobReptilian" Caption="Reptilian"/>
   <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
-  <GuideEntityEmbed Entity="MobAvali" Caption="Avali"/> <!--harmony-->
   </Box>
 
 </Document>

--- a/Resources/ServerInfo/_Harmony/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_Harmony/Guidebook/Mobs/Avali.xml
@@ -1,0 +1,16 @@
+<Document>
+  # Avali
+
+  <Box>
+    <GuideEntityEmbed Entity="MobAvali" Caption=""/>
+  </Box>
+
+  Their unarmed claw attacks deal Slash damage instead of Blunt.
+
+  They take [color=#1e90ff]40% less Cold damage[/color] but [color=#ffa500]10% more Heat damage[/color], and [color=#b72344]15% more Blunt damage[/color].
+
+  Avali also [bold]metabolize chemicals and poisons at 30% additional speed.[/bold]
+
+  Their blood is made up of Ammonia, and can be metabolized from Iron. [bold]Regular ammonia does not replenish their blood level, however.[/bold]
+
+</Document>


### PR DESCRIPTION
## About the PR
Adds guidebook entry for Avali. I will try and maintain it as changes are made.

## Why / Balance
Resolves https://github.com/ss14-harmony/ss14-harmony/issues/938

## Technical details
modifies Guidebook/species.yml in upstream namespace, adds harmony comment
modifies Guidebook/Mobs/Species.xml in upstream namespace, adds harmony comments
adds Guidebook/Mobs/avali.xml in harmony namespace

## Media
<img width="657" height="328" alt="species2" src="https://github.com/user-attachments/assets/aa8f039e-5f60-4c2c-b696-f4ec7a633c4c" />
<img width="798" height="372" alt="species1" src="https://github.com/user-attachments/assets/3d4d7c24-5be1-4c9e-8d57-32fdfed9250b" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added guidebook entry for Avali