### PR TITLE
Lowered the atmospheric pressure on All exped options and combinations

### DIFF
--- a/Resources/Prototypes/Procedural/salvage_mods.yml
+++ b/Resources/Prototypes/Procedural/salvage_mods.yml
@@ -69,7 +69,7 @@
   id: Hot
   desc: salvage-temperature-mod-hot
   cost: 1
-  temperature: 323.15 # 50C
+  temperature: 303.15 # 50C # Harmony Change, 30C
   biomes:
     - Caves
     #- LowDesert
@@ -80,7 +80,7 @@
   id: Burning
   desc: salvage-temperature-mod-high-temperature
   cost: 2
-  temperature: 423.15 # 200C
+  temperature: 333.15 # 200C # Harmony Change, 60C
   biomes:
     - Caves
     #- LowDesert
@@ -90,7 +90,7 @@
   id: Melting
   desc: salvage-temperature-mod-extreme-heat
   cost: 4
-  temperature: 1273.15 # 1000C hot hot hot
+  temperature: 408.15 # 1000C hot hot hot # Harmony Change, 135C
   biomes:
     - Lava
 
@@ -137,16 +137,16 @@
   cost: 0
   desc: salvage-air-mod-breathable-atmosphere
   gases:
-    - 21.824779 # oxygen
-    - 82.10312 # nitrogen
+    - 18.3 # oxygen # Harmony Change - Exped PKAs - 21.824779 > 18.3
+    - 18.3 # nitrogen # Harmony Change - Exped PKAs - 82.10312 > 18.3
 
 - type: salvageAirMod
   id: Sleepy
   cost: 1
   desc: salvage-air-mod-dangerous-atmosphere
   gases:
-    - 21.824779 # oxygen
-    - 72.10312 # nitrogen
+    - 10 # oxygen # Harmony Change - Exped PKAs - 21.824779 > 10
+    - 10 # nitrogen # Harmony Change - Exped PKAs - 72.10312 > 10
     - 0
     - 0
     - 0
@@ -165,8 +165,8 @@
   cost: 2
   desc: salvage-air-mod-dangerous-atmosphere
   gases:
-    - 21.824779 # oxygen
-    - 77.10312 # nitrogen
+    - 10 # oxygen # Harmony Change - Exped PKAs - 21.824779 > 10
+    - 10 # nitrogen # Harmony Change - Exped PKAs - 77.10312 > 10
     - 10 # carbon dioxide
   biomes:
     - Caves
@@ -180,9 +180,9 @@
   cost: 3
   desc: salvage-air-mod-toxic-atmosphere
   gases:
-    - 21.824779 # oxygen
+    - 18.3 # oxygen # Harmony Change - Exped PKAs - 21.824779 > 18.3
     - 0
-    - 82.10312 # carbon dioxide
+    - 18.3 # carbon dioxide # Harmony Change - Exped PKAs - 82.10312 > 18.3
   biomes:
     - Caves
     - Snow
@@ -196,7 +196,7 @@
     - 0
     - 0
     - 0
-    - 103.927899 # plasma
+    - 35 # plasma # Harmony Change - Exped PKAs - 103.927899 > 35
   biomes:
     - Caves
     - Lava
@@ -206,10 +206,10 @@
   cost: 5
   desc: salvage-air-mod-volatile-atmosphere
   gases:
-    - 21.824779 # oxygen
+    - 18.3 # oxygen # Harmony Change - Exped PKAs - 21.824779 > 18.3
     - 0
     - 0
-    - 82.10312 # plasma
+    - 18.3 # plasma # Harmony Change - Exped PKAs - 82.10312 > 18.3
   biomes:
     - Caves
     - Lava


### PR DESCRIPTION
## About the PR
Companion to https://github.com/ss14-harmony/ss14-harmony/pull/934. Requires said PR.

Reworks all expedition atmosphere options to accomodate the PKA having a pressure cap of 50kPa,
Also reworks the maximum temperature findable on expeds or this would be impossible.

## Why / Balance
If the DeltaV pressure projectile change is merged, then PKAs become fundementally useless on expeditions. Seeing as expeditions are still currently on the table as something available to Salvage, this break in functionality poses an issue.

By reducing the atmosphere of all planets findeable on expeditions to cap out at 50kPa, even at the highest temperatures, the PKA can be used on expeditions again, meaning salvagers don't have to resort to alternative means of killing carp and xenos planet-side.

Atmospheres intended to be breathable are still breathable.

## Technical details
Modified multiple Upstream prototypes in Resources/Prototypes/Procedural/salvage_mods.yml

## Media
<img width="1514" height="708" alt="image" src="https://github.com/user-attachments/assets/373cf0f9-5f1f-4b14-9d65-ef5eac3c56f9" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: The atmospheres of planets findable on Expeditions have been tweaked to accomodate the changes to the Proto-Kinetic Accelerator


