### PR TITLE
Rename Blood Brother to Blood Bound Lite (Player Facing Only)

### DIFF
--- a/Resources/Locale/en-US/_Harmony/administration/antag.ftl
+++ b/Resources/Locale/en-US/_Harmony/administration/antag.ftl
@@ -1,3 +1,3 @@
-admin-verb-make-blood-brother = Make the target into a Blood Brother.
+admin-verb-make-blood-brother = Make the target into a Blood Bound.
 
-admin-verb-text-make-blood-brother = Make Blood Brother
+admin-verb-text-make-blood-brother = Make Blood Bound

--- a/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-bloodbrother.ftl
+++ b/Resources/Locale/en-US/_Harmony/game-ticking/game-presets/preset-bloodbrother.ftl
@@ -1,27 +1,27 @@
-blood-brothers-round-end-agent-name = blood brother
+blood-brothers-round-end-agent-name = blood bound
 
-objective-issuer-blood-brother = [color=mediumvioletred]The Brotherhood[/color]
+objective-issuer-blood-brother = [color=mediumvioletred]The Blood Oath[/color]
 
 blood-brother-round-end-no-mind = [color=white]{CAPITALIZE($name)}[/color] ([color=gray]{$username}[/color]) was oath-bound with [color=white]{$brotherName}[/color].
 blood-brother-round-end = [color=white]{CAPITALIZE($name)}[/color] ([color=gray]{$username}[/color]) was oath-bound with [color=white]{$brotherName}[/color] ([color=gray]{$brotherUsername}[/color]).
 
 blood-brother-initial-role-greeting =
-    You are a blood brother.
+    You are a blood bound.
     You have been given the ability to take a blood oath with one member of the crew.
     Use this ability wisely and finish your objectives given to you by an anonymous source.
 
 blood-brother-role-greeting =
     You have been sworn into a blood oath.
-    Listen to your blood brother and help them accomplish their objectives
+    Listen to your blood bound and help them accomplish their objectives
 
-blood-brother-briefing = Collaborate with your blood brother to accomplish all your objectives.
+blood-brother-briefing = Collaborate with your blood bound to accomplish all your objectives.
 
 blood-brother-break-control = {CAPITALIZE(THE($name))} has remembered their true allegiance!
 
 # Conversion
 
 blood-brother-convert-failed-no-mind = {CAPITALIZE(THE($converted))} does not have a mind
-blood-brother-convert-failed-already-brother = {CAPITALIZE(THE($converted))} is already a blood brother
+blood-brother-convert-failed-already-brother = {CAPITALIZE(THE($converted))} is already a blood bound
 blood-brother-convert-failed-target = {CAPITALIZE(THE($converted))} is your target
 blood-brother-convert-failed-zombie = {CAPITALIZE(THE($converted))} is a zombie
 blood-brother-convert-failed-shielded = {CAPITALIZE(THE($converted))}'s mind is too protected

--- a/Resources/Locale/en-US/_Harmony/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Harmony/guidebook/guides.ftl
@@ -1,7 +1,7 @@
 guide-entry-rules-sl-restricted-list = Restricted Lists
 guide-entry-rules-sop = Standard Operating Procedure
 
-guide-entry-blood-brothers = Blood Brothers
+guide-entry-blood-brothers = Blood Bound
 
 guide-entry-rules-harmony-title = Harmony Rules
 guide-entry-rules-harmony-r0 = R0

--- a/Resources/Locale/en-US/_Harmony/mind/role-types.ftl
+++ b/Resources/Locale/en-US/_Harmony/mind/role-types.ftl
@@ -1,1 +1,1 @@
-role-subtype-blood-brother = Blood Brother
+role-subtype-blood-brother = Blood Bound

--- a/Resources/Locale/en-US/_Harmony/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_Harmony/prototypes/roles/antags.ftl
@@ -1,3 +1,3 @@
-roles-antag-blood-brother-name = Blood Brother (Initial)
-roles-antag-blood-brother-convertible-name = Blood Brother (Converted)
-roles-antag-blood-brother-objective = Collaborate with your blood brother to accomplish all your objectives.
+roles-antag-blood-brother-name = Blood Bound (Initial)
+roles-antag-blood-brother-convertible-name = Blood Bound (Converted)
+roles-antag-blood-brother-objective = Collaborate with your blood bound to accomplish all your objectives.

--- a/Resources/Prototypes/_Harmony/Actions/blood_brothers.yml
+++ b/Resources/Prototypes/_Harmony/Actions/blood_brothers.yml
@@ -2,7 +2,7 @@
   parent: BaseAction
   id: ActionBloodBrotherConvert
   name: Convert
-  description: Convert a crewmember to your brotherhood.
+  description: Convert a crewmember to your blood oath.
   components:
   - type: Action
     icon:

--- a/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
@@ -13,7 +13,7 @@
 - type: entity
   parent: [BaseBloodBrotherObjective, BaseTargetObjective]
   id: BloodBrotherConvertedObjective
-  name: Help your brother.
+  name: Help your blood bound.
   description: Assist your blood bound in completing all of their objectives no matter the cost.
   components:
   - type: Objective

--- a/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/bloodbrother.yml
@@ -14,7 +14,7 @@
   parent: [BaseBloodBrotherObjective, BaseTargetObjective]
   id: BloodBrotherConvertedObjective
   name: Help your brother.
-  description: Assist your brother in completing all of their objectives no matter the cost.
+  description: Assist your blood bound in completing all of their objectives no matter the cost.
   components:
   - type: Objective
     difficulty: 0 # never given randomly anyways

--- a/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml
@@ -14,6 +14,6 @@
   - [textlink="Nuclear operatives" link="Nuclear Operatives"], with the goal of infiltrating and destroying the station.
   - [textlink="Space Ninjas" link="SpaceNinja"], masters of espionage and sabotage with special gear.
   - [textlink="Zombies" link="Zombies"] that crave the flesh of every crew member and creature on board.
-  - [textlink="Blood Brothers" link="BloodBrothers"] who need to work together to complete a set of objectives.
+  - [textlink="Blood Bound" link="BloodBrothers"] who need to work together to complete a set of objectives. <!--Harmony Change - Adds BB-->
   - [textlink="Various non-humanoid creatures" link="MinorAntagonists"] that generally attack anything that moves.
 </Document>

--- a/Resources/ServerInfo/_Harmony/Guidebook/Antagonist/BloodBrothers.xml
+++ b/Resources/ServerInfo/_Harmony/Guidebook/Antagonist/BloodBrothers.xml
@@ -1,10 +1,10 @@
 <Document>
-  # Blood Brothers
+  # Blood Bound
 
   <Box>
-    [color=#999999][italic]"I must help my brother, no matter the cost."[/italic][/color]
+    [color=#999999][italic]"I must help my blood bound, no matter the cost."[/italic][/color]
   </Box>
-  Blood Brothers are a team of two people working together to complete a list of objectives. These objectives are mostly equal to the objectives given to [textlink="Traitors" link="Traitors"].
+  The Blood Bound are a team of two people working together to complete a list of objectives. These objectives are mostly equal to the objectives given to [textlink="Traitors" link="Traitors"].
 
   ## What to do
 
@@ -16,7 +16,7 @@
 
   This action will quietly check and tell you if someone is possible to convert or not.
 
-  You will not be able to convert anyone who is mindshielded or anyone who has blood brothers turned off in their character creation panel.
+  You will not be able to convert anyone who is mindshielded or anyone who has blood bound turned off in their character creation panel.
 
   ### Converting a crewmember
 
@@ -24,5 +24,5 @@
 
   To do so, you must first bring them to a hidden location where no one will see and then use the "Convert" action. This action is [bold]very visible[/bold], do not use it in public.
 
-  The crewmember will then become your blood brother, with the objective to help you with your objectives.
+  The crewmember will then become your blood bound, with the objective to help you with your objectives.
 </Document>


### PR DESCRIPTION
### _The code in this PR is also available under the MIT license._

## About the PR
Renames the antagonist introduced in https://github.com/ss14-harmony/ss14-harmony/pull/638
This is a less intense version of https://github.com/ss14-harmony/ss14-harmony/pull/864, unlike that one this one only changes the strings (player facing stuff)

## Why / Balance
See PR #864

## Technical details
Changed all instance of blood brother to blood bound in ftl files, yaml descriptions, and guidebook xmls
Added a missing comment to Resources/ServerInfo/Guidebook/Antagonist/Antagonists.xml for the BB line.

## Media
See PR #864

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Blood Brother has been renamed to Blood Bound.
