### PR TITLE
Revert "Advanced Chem Tweaks"

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -862,7 +862,7 @@
   color: "#520e30"
   metabolisms:
     Medicine:
-      metabolismRate: 0.25
+      # metabolismRate: 0.25 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         conditions:
@@ -871,15 +871,15 @@
           max: 30
         damage:
           groups:
-            Toxin: -1.5
-            Brute: 0.25
+            Toxin: -3 # Harmony - Revert Advanced Chem Change
+            Brute: 0.5 # Harmony - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: -0.5
+            Toxin: -1 # Harmony - Revert Advanced Chem Change
             Brute: 3
       - !type:AdjustReagent
         conditions:
@@ -989,19 +989,19 @@
   color: "#e0a5b9"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Caustic: -0.6 # 6 per u
+            Caustic: -3 # Harmony - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 16 # Harmony - Revert Advanced Chem Change
         damage:
           types:
-            Heat: 0.2
+            Heat: 2 # Harmony - Revert Advanced Chem Change
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -1045,19 +1045,19 @@
   color: "#283332"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Slash: -0.6 # 6 Per u
+            Slash: -3 # Harmony - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 12 # Harmony - Revert Advanced Chem Change
         damage:
           types:
-            Cold: 1.5 #15 per u
+            Cold: 3 # Harmony - Revert Advanced Chem Change
 
 - type: reagent
   id: Puncturase
@@ -1069,20 +1069,20 @@
   color: "#b9bf93"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Piercing: -0.6 # 6 per u
-            Blunt: 0.05 # 0.5 per u
+            Piercing: -4 # Harmony - Revert Advanced Chem Change
+            Blunt: 0.1 # Harmony - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 21
+          min: 11 # Harmony - Revert Advanced Chem Change
         damage:
           types:
-            Blunt: 1 # 10 per u plus base effect
+            Blunt: 5 # Harmony - Revert Advanced Chem Change
 
 - type: reagent
   id: Bruizine
@@ -1094,19 +1094,19 @@
   color: "#ff3636"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
       effects:
       - !type:HealthChange
         damage:
           types:
-            Blunt: -0.6 # 6 per u
+            Blunt: -3.5 # Harmony - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 19
+          min: 10.5 # Harmony - Revert Advanced Chem Change
         damage:
           types:
-            Poison: 1.5 # 15 per u
+            Poison: 4 # Harmony - Revert Advanced Chem Change
 
 - type: reagent
   id: Holywater
@@ -1201,13 +1201,13 @@
   color: "#8147ff"
   metabolisms:
     Medicine:
-      metabolismRate: 0.1
+      # metabolismRate: 0.1 # Harmony - Revert Advanced Chem Change
       effects:
       # heals shocks and removes shock chems
       - !type:HealthChange
         damage:
           types:
-            Shock: -0.5 # 5 per u
+            Shock: -4 # Harmony - Revert Advanced Chem Change
       - !type:AdjustReagent
         reagent: Licoxide
         amount: -4
@@ -1221,14 +1221,14 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 15.5
+          min: 12 # Harmony - Revert Advanced Chem Change
         damage:
           types:
-            Cold: 0.2 # 2 per u but lethal with cooling OD effect below
+            Cold: 2 # Harmony - Revert Advanced Chem Change
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-          min: 15.5
+          min: 12 # Harmony - Revert Advanced Chem Change
         amount: -30000
       - !type:Jitter
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -871,15 +871,15 @@
           max: 30
         damage:
           groups:
-            Toxin: -3 # Harmony - Revert Advanced Chem Change
-            Brute: 0.5 # Harmony - Revert Advanced Chem Change
+            Toxin: -3 # Harmony - -1.5 > -3 - Revert Advanced Chem Change
+            Brute: 0.5 # Harmony - 0.25 > 0.5 - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: -1 # Harmony - Revert Advanced Chem Change
+            Toxin: -1 # Harmony - -0.5 > -1 - Revert Advanced Chem Change
             Brute: 3
       - !type:AdjustReagent
         conditions:
@@ -994,14 +994,14 @@
       - !type:HealthChange
         damage:
           types:
-            Caustic: -3 # Harmony - Revert Advanced Chem Change
+            Caustic: -3 # Harmony - -0.6 > -3 - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 16 # Harmony - Revert Advanced Chem Change
+          min: 16 # Harmony - 21 > 16 - Revert Advanced Chem Change
         damage:
           types:
-            Heat: 2 # Harmony - Revert Advanced Chem Change
+            Heat: 2 # Harmony - 0.2 > 2 - Revert Advanced Chem Change
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -1050,14 +1050,14 @@
       - !type:HealthChange
         damage:
           types:
-            Slash: -3 # Harmony - Revert Advanced Chem Change
+            Slash: -3 # Harmony - -0.6 > -3 - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 12 # Harmony - Revert Advanced Chem Change
+          min: 12 # Harmony - 21 > 12 - Revert Advanced Chem Change
         damage:
           types:
-            Cold: 3 # Harmony - Revert Advanced Chem Change
+            Cold: 3 # Harmony - 1.5 > 3 - Revert Advanced Chem Change
 
 - type: reagent
   id: Puncturase
@@ -1074,15 +1074,15 @@
       - !type:HealthChange
         damage:
           types:
-            Piercing: -4 # Harmony - Revert Advanced Chem Change
-            Blunt: 0.1 # Harmony - Revert Advanced Chem Change
+            Piercing: -4 # Harmony - -0.6 > -4 - Revert Advanced Chem Change
+            Blunt: 0.1 # Harmony - 0.05 > 0.1 - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 11 # Harmony - Revert Advanced Chem Change
+          min: 11 # Harmony - 21 > 11 - Revert Advanced Chem Change
         damage:
           types:
-            Blunt: 5 # Harmony - Revert Advanced Chem Change
+            Blunt: 5 # Harmony - 1 > 5 - Revert Advanced Chem Change
 
 - type: reagent
   id: Bruizine
@@ -1099,14 +1099,14 @@
       - !type:HealthChange
         damage:
           types:
-            Blunt: -3.5 # Harmony - Revert Advanced Chem Change
+            Blunt: -3.5 # Harmony - -0.6 > -3.5 - Revert Advanced Chem Change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 10.5 # Harmony - Revert Advanced Chem Change
+          min: 10.5 # Harmony - 19 > 10.5 - Revert Advanced Chem Change
         damage:
           types:
-            Poison: 4 # Harmony - Revert Advanced Chem Change
+            Poison: 4 # Harmony - 1.5 > 4 - Revert Advanced Chem Change
 
 - type: reagent
   id: Holywater
@@ -1207,7 +1207,7 @@
       - !type:HealthChange
         damage:
           types:
-            Shock: -4 # Harmony - Revert Advanced Chem Change
+            Shock: -4 # Harmony - 0.5 > 4 - Revert Advanced Chem Change
       - !type:AdjustReagent
         reagent: Licoxide
         amount: -4
@@ -1221,14 +1221,14 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 12 # Harmony - Revert Advanced Chem Change
+          min: 12 # Harmony - 15.5 > 12 - Revert Advanced Chem Change
         damage:
           types:
-            Cold: 2 # Harmony - Revert Advanced Chem Change
+            Cold: 2 # Harmony - 0.2 > 2 - Revert Advanced Chem Change
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-          min: 12 # Harmony - Revert Advanced Chem Change
+          min: 12 # Harmony - 15.5 > 12 - Revert Advanced Chem Change
         amount: -30000
       - !type:Jitter
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -142,9 +142,10 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:EvenHealthChange
+      - !type:HealthChange
         damage:
-          Brute: -1.5
+          groups:
+            Brute: -2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -144,8 +144,10 @@
       effects:
       - !type:HealthChange # Harmony Change - EvenHealthChange > HealthChange - Reverts advanced chem rework
         damage:
-          groups: # Harmony Change - needed for EvenHealthChange > HealthChange
-            Brute: -2 # Harmony Change - -1.5 > -2 - Reverts advanced chem rework
+# Start Harmony change - Reverts advanced chem rework
+          groups: 
+            Brute: -2 # -1.5 > -2
+# End Harmony change
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -142,10 +142,10 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
+      - !type:HealthChange # Harmony Change - EvenHealthChange > HealthChange - Reverts advanced chem rework
         damage:
-          groups:
-            Brute: -2
+          groups: # Harmony Change - needed for EvenHealthChange > HealthChange
+            Brute: -2 # Harmony Change - -1.5 > -2 - Reverts advanced chem rework
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_Harmony/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Harmony/Recipes/Reactions/medicine.yml
@@ -12,3 +12,37 @@
       amount: 1
   products:
     Barozine: 2
+
+# Readds Bic Razorium
+- type: reaction
+  id: BicarLacerinol # mixing any two brute medications will make Razorium
+  impact: Medium
+  reactants:
+    Lacerinol:
+      amount: 1
+    Bicaridine:
+      amount: 1
+  products:
+    Razorium: 1
+
+- type: reaction
+  id: BicarPuncturase # mixing any two brute medications will make Razorium
+  impact: Medium
+  reactants:
+    Puncturase:
+      amount: 1
+    Bicaridine:
+      amount: 1
+  products:
+    Razorium: 1
+
+- type: reaction
+  id: BicarBruizine # mixing any two brute medications will make Razorium
+  impact: Medium
+  reactants:
+    Bruizine:
+      amount: 1
+    Bicaridine:
+      amount: 1
+  products:
+    Razorium: 1


### PR DESCRIPTION
## About the PR
Reverts https://github.com/space-wizards/space-station-14/pull/38811.

## Why / Balance
Mutiple requests were made for a day 1 reversion.

Since this PR was created, [this thread went up](https://discord.com/channels/1139716325627932682/1402791675734003885).

Given the feedback in Harmony, it seems safe to say this direction is not one the medical playerbase here wants to go on.
Upstream Balance and Harmony Balance are different.

## Technical details
Reverts all changes to the advanced chems in Resources/Prototypes/Reagents/medicine.yml.

Readds bic + advance brutes making razorium in Resources/Prototypes/_Harmony/Recipes/Reactions/medicine.yml.

## Media
<img alt="image" src="https://github.com/user-attachments/assets/bfba70d7-bd20-4f2a-a32f-4a507bcdf01f" />

<img alt="image" src="https://github.com/user-attachments/assets/f3315850-d8f7-41ca-ba42-425822662e0a" />

<img alt="image" src="https://github.com/user-attachments/assets/e5cdf261-5f95-4f36-b0a3-99508e3ee2db" />

<img width="663" height="300" alt="image" src="https://github.com/user-attachments/assets/d3c63aa6-be04-4df1-890b-71e660a22cd7" />

<img width="657" height="417" alt="image" src="https://github.com/user-attachments/assets/41377303-62b3-4e61-8613-65d68f477e92" />

<img width="656" height="664" alt="image" src="https://github.com/user-attachments/assets/c45f916e-91f8-4369-a50e-a436012cb6d5" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Reverted changes to several advanced chems.
- tweak: Bicaridine makes razorium when mixed with advanced brute chems again.

