### PR TITLE
Bingle Weight Loss

### DIFF
--- a/Resources/Prototypes/_Harmony/GameRules/events.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/events.yml
@@ -19,7 +19,7 @@
   id: BingleSpawn
   components:
   - type: StationEvent
-    weight: 5 # Currently equal to a paradox clone
+    weight: 3.5 # Equal to a Dragon
     duration: null
     earliestStart: 30
     reoccurrenceDelay: 90 # 1h30 between each bingle


### PR DESCRIPTION
## About the PR/Balance
Reduces Bingle event weight to be equal to that of a Space Dragon. Bingles are weird little space creatures and ought to be a bit rarer to increase their impact.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Minor tweak, no CL