### PR TITLE
Adds New Outcomes to Ninja Hacking

### DIFF
--- a/Resources/Locale/en-US/_Harmony/communications/terror.ftl
+++ b/Resources/Locale/en-US/_Harmony/communications/terror.ftl
@@ -1,0 +1,4 @@
+terror-space = Attention crew, it appears that someone on your station has made an unexpected communication with an unknown object in nearby space.
+terror-otherworldly = Attention crew, it appears that someone on your station has made an unexpected communication with an otherworldly entity in nearby space.
+terror-loneop = Attention crew, it appears that someone on your station has made an unexpected communication with an enemy corporation in nearby space.
+terror-wizard = Attention crew, it appears that someone on your station has made an unexpected communication with an anomalous magical individual in nearby space.

--- a/Resources/Prototypes/_Harmony/threats.yml
+++ b/Resources/Prototypes/_Harmony/threats.yml
@@ -1,0 +1,24 @@
+- type: ninjaHackingThreat
+  id: LoneOp
+  announcement: terror-loneop
+  rule: LoneOpsSpawn
+
+- type: ninjaHackingThreat
+  id: Wizard
+  announcement: terror-wizard
+  rule: WizardSpawn
+
+- type: ninjaHackingThreat
+  id: DerelictBorg
+  announcement: terror-space
+  rule: DerelictCyborgSpawn
+
+- type: ninjaHackingThreat
+  id: ParadoxClone
+  announcement: terror-otherworldly
+  rule: ParadoxCloneSpawn
+
+- type: ninjaHackingThreat
+  id: Bingle
+  announcement: terror-otherworldly
+  rule: BingleSpawn

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -2,15 +2,24 @@
 - type: weightedRandom
   id: NinjaThreats
   weights:
-    Dragon: 1
-    Revenant: 1
+    #Dragon: 1
+    #Revenant: 1
+    #Begin Harmony Change - expanded pool of spawns.
+    LoneOp: 0.25
+    Wizard: 0.25
+    DerelictBorg: 1
+    ParadoxClone: 1
+    Bingle: 1
+    #End Harmony Change - expanded pool of spawns.
 
 - type: ninjaHackingThreat
   id: Dragon
-  announcement: terror-dragon
+  #announcement: terror-dragon
+  announcement: terror-space # Harmony Change - censors dragon spawn to keep threat secret with expanded spawn pool.
   rule: DragonSpawn
 
 - type: ninjaHackingThreat
   id: Revenant
-  announcement: terror-revenant
+  #announcement: terror-revenant
+  announcement: terror-otherworldly #Harmony change - censors rev spawn to keep htreat secret with expanded pool.
   rule: RevenantSpawn


### PR DESCRIPTION
## About the PR
This PR adds new outcomes to the event that rolls when a ninja succesfully hacks a comms console.
It also adds three generic messages that replace the specific messages, to help make the element of surprise better.

Right now this PR adds the following mobs, sorted into the following buckets:
Space Threats: Dragon, Derelict
Otherwordly Entity: Paradox, Bingle, Revenant
Enemy Corpo: LoneOp
Magical Threat: Wizard

Everything except the LoneOp and Wizard are weighted at 1, and the former two are weighted at 0.25. This gives them about a 5% chance of spawning each - not to mention its locked behind a ninja spawning, and managing to hack the console.

## Why / Balance
-Currently the hacking event doesnt feel like a 50/50 chance between two antagonists. It feels like a dragon, or nothing. Namely this is because people dont tend to pick up revenants, and they're a bit of a nothingburger antagonist compared to the space dragon.
-by adding seperate pools with generic messages, you're not quite sure what you're gonna get. Is that deep space communication a dragon, or a derelict borg? Is that otherworldly entity a revenant, or a paradox clone?
-Wizards and LoneOps, due to their ability to end a round much easier than the others, have unique, clear messages that mark them as a threat security need to respond to ASAP. I thought it would be unfun for security to be caught off guard by a lone-op. I think leaving them abigious would leave security to respond heavy handed to smaller threats. this is a nice middle ground.

## Technical details
-Modifies the spawner table in resources/prototypes/threats.yml to add the new entries.
-also modifies the dragon and revenant entries in the same file as above to make them use the new message pools.
-creates a new file under resources/locale/en-us/_harmony/communications/terror.ftl to add new flavor text for event spawn.
-creates a new file undr resources/prototypes/_harmony/threats.yml to contain the new threat systems to compliment the upstream file.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- add: Adds new outcomes to a Ninja hacking a comms console. They can now call in paradox clones, bingles, ion borgs and in rare cases a lone-op or wizard.

