### PR TITLE
End the Reign of Terror over atmos

### DIFF
--- a/Content.Shared/Atmos/Components/GasTankComponent.cs
+++ b/Content.Shared/Atmos/Components/GasTankComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Atmos.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class GasTankComponent : Component, IGasMixtureHolder
 {
-    public const float MaxExplosionRange = 400f; //Harmony - 1984 removed
+    public const float MaxExplosionRange = 400f; //Harmony - cap set to 400 from 26 to effectively uncap the value
     private const float DefaultLowPressure = 0f;
     private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 

--- a/Content.Shared/Atmos/Components/GasTankComponent.cs
+++ b/Content.Shared/Atmos/Components/GasTankComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared.Atmos.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class GasTankComponent : Component, IGasMixtureHolder
 {
-    public const float MaxExplosionRange = 26f;
+    public const float MaxExplosionRange = 400f; //Harmony - 1984 removed
     private const float DefaultLowPressure = 0f;
     private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removes the maximum cap on tank explosions
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The current maximum maxcap radius is 26, but this is ALREADY a shift-ending catastrophe of a bomb - same with a loose, and any ol' engi has access to that. That said, we don't have any issues with raiders loosing or making maxcaps on harmony ANYWAY - why not give a hyper-competent dagd atmos a little fun?

## Technical details
<!-- Summary of code changes for easier review. -->
Maximum explosion cap radius changed from 26 -> 400 (this is unreachably high even with admin)

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Uncapped maxcaps

