### PR TITLE
Improve queue admin logging

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -56,20 +56,24 @@ namespace Content.Server.GameTicking
                     // timer time must be > tick length
                     // Timer.Spawn(0, () => _playerManager.JoinGame(args.Session)); - Harmony Queue: Removed line, login is done by JoinQueueManager
 
-                    var record = await _db.GetPlayerRecordByUserId(args.Session.UserId);
-                    var firstConnection = record != null &&
-                                          Math.Abs((record.FirstSeenTime - record.LastSeenTime).TotalMinutes) < 1;
+                    // Harmony start - move to the ingame session status
+                    // var record = await _db.GetPlayerRecordByUserId(args.Session.UserId);
+                    // var firstConnection = record != null &&
+                    //                       Math.Abs((record.FirstSeenTime - record.LastSeenTime).TotalMinutes) < 1;
 
-                    _chatManager.SendAdminAnnouncement(firstConnection
-                        ? Loc.GetString("player-first-join-message", ("name", args.Session.Name))
-                        : Loc.GetString("player-join-message", ("name", args.Session.Name)));
+                    // _chatManager.SendAdminAnnouncement(firstConnection
+                    //     ? Loc.GetString("player-first-join-message", ("name", args.Session.Name))
+                    //     : Loc.GetString("player-join-message", ("name", args.Session.Name)));
+                    // Harmony end
 
                     RaiseNetworkEvent(GetConnectionStatusMsg(), session.Channel);
 
-                    if (firstConnection && _cfg.GetCVar(CCVars.AdminNewPlayerJoinSound))
-                        _audio.PlayGlobal(new SoundPathSpecifier("/Audio/Effects/newplayerping.ogg"),
-                            Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false,
-                            audioParams: new AudioParams { Volume = -5f });
+                    // Harmony start - move to the ingame session status
+                    // if (firstConnection && _cfg.GetCVar(CCVars.AdminNewPlayerJoinSound))
+                    //     _audio.PlayGlobal(new SoundPathSpecifier("/Audio/Effects/newplayerping.ogg"),
+                    //         Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false,
+                    //         audioParams: new AudioParams { Volume = -5f });
+                    // Harmony end
 
                     if (LobbyEnabled && _roundStartCountdownHasNotStartedYetDueToNoPlayers)
                     {
@@ -83,6 +87,21 @@ namespace Content.Server.GameTicking
                 case SessionStatus.InGame:
                 {
                     _userDb.ClientConnected(session);
+
+                    // Harmony start - move join logging to the in game session status
+                    var record = await _db.GetPlayerRecordByUserId(args.Session.UserId);
+                    var firstConnection = record != null &&
+                                               Math.Abs((record.FirstSeenTime - record.LastSeenTime).TotalMinutes) < 1;
+
+                    _chatManager.SendAdminAnnouncement(firstConnection
+                        ? Loc.GetString("player-first-join-message", ("name", args.Session.Name))
+                        : Loc.GetString("player-join-message", ("name", args.Session.Name)));
+
+                    if (firstConnection && _cfg.GetCVar(CCVars.AdminNewPlayerJoinSound))
+                        _audio.PlayGlobal(new SoundPathSpecifier("/Audio/Effects/newplayerping.ogg"),
+                            Filter.Empty().AddPlayers(_adminManager.ActiveAdmins), false,
+                            audioParams: new AudioParams { Volume = -5f });
+                    // Harmony end
 
                     if (mind == null)
                     {

--- a/Content.Server/_Harmony/JoinQueue/JoinQueueManager.cs
+++ b/Content.Server/_Harmony/JoinQueue/JoinQueueManager.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using Content.Shared._Harmony.CCVars;
 using Content.Server.Administration.Managers;
+using Content.Server.Chat.Managers;
 
 namespace Content.Server._Harmony.JoinQueue;
 
@@ -38,6 +39,7 @@ public sealed class JoinQueueManager : IJoinQueueManager
     [Dependency] private readonly IServerNetManager _net = default!;
     [Dependency] private readonly IConnectionManager _connection = default!;
     [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
 
     /// <summary>
     /// Queue of active player sessions
@@ -107,6 +109,12 @@ public sealed class JoinQueueManager : IJoinQueueManager
         }
         else
         {
+            _chatManager.SendAdminAnnouncement(
+                Loc.GetString(
+                    "player-join-queue-message",
+                    ("name", session.Name),
+                    ("queueCount", PlayerInQueueCount + 1)));
+
             _queue.Add(session);
         }
 

--- a/Resources/Locale/en-US/_Harmony/queue/queue.ftl
+++ b/Resources/Locale/en-US/_Harmony/queue/queue.ftl
@@ -1,0 +1,1 @@
+player-join-queue-message = Player {$name} joined the queue. ({$queueCount} in queue)


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
When a player joins the queue, the admin message will now say "Player {player} joined the queue. ({$number} in queue)"
The message that a player has joined the game will now only happen after the player has reached the end of the queue and is actually in-game

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Admin tools are always good

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
