### PR TITLE
burn and overheat changes for moth and avali

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -55,7 +55,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 4.5 # moths burn more easily
+        Heat: 2.25 # harmony, 4.5 -> 2.25
   - type: Temperature # Moths hate the heat and thrive in the cold.
     heatDamageThreshold: 320
     coldDamageThreshold: 230
@@ -66,7 +66,7 @@
         Cold : 0.05 #per second, scales with temperature & other constants
     heatDamage:
       types:
-        Heat : 3 #per second, scales with temperature & other constants
+        Heat : 1.5 # harmony 3.0 -> 1.5, per second, scales with temperature & other constants
   - type: TemperatureSpeed
     thresholds:
       289: 0.9

--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
@@ -74,14 +74,14 @@
       265: 0.8
       251: 0.6
       226: 0.4
-  #- type: ThermalRegulator
-    #metabolismHeat: 400 # icebirb go brrr
-    #radiatedHeat: 100
-    #implicitHeatRegulation: 500
-    #sweatHeatRegulation: 2000
-    #shiveringHeatRegulation: 2000
-    #normalBodyTemperature: 296.15
-    #thermalRegulationTemperatureThreshold: 10
+  - type: ThermalRegulator
+    metabolismHeat: 400 # icebirb go brrr
+    radiatedHeat: 100
+    implicitHeatRegulation: 500
+    sweatHeatRegulation: 2000
+    shiveringHeatRegulation: 2000
+    normalBodyTemperature: 296.15
+    thermalRegulationTemperatureThreshold: 10
 # Start harmony change
 #  - type: Metabolizer
 #    solutionOnBody: false

--- a/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_CD/Entities/Mobs/Species/avali.yml
@@ -68,20 +68,20 @@
         Cold : 0.05 #per second, scales with temperature & other constants
     heatDamage:
       types:
-        Heat : 3 #per second, scales with temperature & other constants
+        Heat : 1.5 #harmony 3.0 -> 1.5, per second, scales with temperature & other constants
   - type: TemperatureSpeed
     thresholds: # all temps are 10K colder then moths, adjusted for current temp.
       265: 0.8
       251: 0.6
       226: 0.4
-  - type: ThermalRegulator
-    metabolismHeat: 400 # icebirb go brrr
-    radiatedHeat: 100
-    implicitHeatRegulation: 500
-    sweatHeatRegulation: 2000
-    shiveringHeatRegulation: 2000
-    normalBodyTemperature: 296.15
-    thermalRegulationTemperatureThreshold: 10
+  #- type: ThermalRegulator
+    #metabolismHeat: 400 # icebirb go brrr
+    #radiatedHeat: 100
+    #implicitHeatRegulation: 500
+    #sweatHeatRegulation: 2000
+    #shiveringHeatRegulation: 2000
+    #normalBodyTemperature: 296.15
+    #thermalRegulationTemperatureThreshold: 10
 # Start harmony change
 #  - type: Metabolizer
 #    solutionOnBody: false


### PR DESCRIPTION
## About the PR
I've seen an awful amount of moths ashing from simply being lit on fire and forgotten for a minute. While accidents happen in SS14 all the time, being instantly killed and ashed because you touched a burning body, got shot by incends, or otherwise, is insane. Species should definitely have strengths and weaknesses, but I don't think resistance to cold and improved no-grav is enough to justify lighting up like a christmas tree. This aims to correct that while still keeping it a weakness.

## Why / Balance
I lowered both Moth and Avali overheat damage from 3.0 to 1.5, matching the species standard. I also lowered fire damage (being on fire) from 4.5 (300%!) heat to 2.25 (150%). The standard is 1.5, for comparison. Moths still take an additional 30% heat overall. This results in moths still being vulnerable to both heat and burn, but it's not an instant death sentence and likely RR. It's important to note that Avali still heat up quicker than other species, and will end up taking more overheat damage overall, despite
damage being lowered to standard. 

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed Avali and Moths to be less susceptible to damage from both overheat and burning.
