### PR TITLE
Trinket Pins Now Use A Dropdown

### DIFF
--- a/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml
@@ -4,54 +4,63 @@
   storage:
     back:
     - ClothingNeckVulturePin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckMirosPin
   storage:
     back:
     - ClothingNeckMirosPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckSalamanderPin
   storage:
     back:
     - ClothingNeckSalamanderPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckLizardPin
   storage:
     back:
     - ClothingNeckLizardPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckLeviathanPin
   storage:
     back:
     - ClothingNeckLeviathanPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckFrontierPin
   storage:
     back:
     - ClothingNeckFrontierPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckCosmaticDriftPin
   storage:
     back:
     - ClothingNeckCosmaticDriftPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckDeltaVPin
   storage:
     back:
     - ClothingNeckDeltaVPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckAxolotlPin
   storage:
     back:
     - ClothingNeckAxolotlPin
+  groupBy: "pins"
 
 - type: loadout
   id: ClothingNeckLanyard


### PR DESCRIPTION
## About the PR
Not much to talk about with this one. I'm simply taking advantage of the trinket downdown menu system to group up all the server pins into a dropdown menu.

## Why / Balance
- decreases the size of the trinkets screen by at least 8 entries. Makes it easier for the player to look through it all. 
- Opens up space for more trinkets in the future without worrying about UI bloat.

## Technical details
- Adds groupby: fields to all relevant entries in Resources/Prototypes/_Harmony/Loadouts/Miscellaneous/trinkets.yml.

## Media
![prmedia1](https://github.com/user-attachments/assets/27d4530d-71ec-4d8d-974e-3ec3df2368ad)

![prmedia2](https://github.com/user-attachments/assets/293e690b-e934-46a3-a5c8-e03e8e4969b7)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Server pin trinkets now use a dropdown menu system similar to cigarettes.


