### PR TITLE
Fixes Ninja Spawn PR To Work With New Borg Ghost Roles

### DIFF
--- a/Resources/Prototypes/_Harmony/threats.yml
+++ b/Resources/Prototypes/_Harmony/threats.yml
@@ -1,24 +1,50 @@
-- type: ninjaHackingThreat
-  id: LoneOp
-  announcement: terror-loneop
-  rule: LoneOpsSpawn
+#- type: ninjaHackingThreat
+#  id: LoneOp
+#  announcement: terror-loneop
+#  rule: LoneOpsSpawn
+
+#- type: ninjaHackingThreat
+#  id: Wizard
+#  announcement: terror-wizard
+#  rule: WizardSpawn
 
 - type: ninjaHackingThreat
-  id: Wizard
-  announcement: terror-wizard
-  rule: WizardSpawn
-
-- type: ninjaHackingThreat
-  id: DerelictBorg
+  id: DerelictBorgEngineering
   announcement: terror-space
-  rule: DerelictCyborgSpawn
+  rule: DerelictEngineerCyborgSpawn
 
 - type: ninjaHackingThreat
-  id: ParadoxClone
-  announcement: terror-otherworldly
-  rule: ParadoxCloneSpawn
+  id: DerelictBorgGeneric
+  announcement: terror-space
+  rule:  DerelictGenericCyborgSpawn
 
 - type: ninjaHackingThreat
-  id: Bingle
-  announcement: terror-otherworldly
-  rule: BingleSpawn
+  id: DerelictBorgJanitor
+  announcement: terror-space
+  rule: DerelictJanitorCyborgSpawn
+
+- type: ninjaHackingThreat
+  id: DerelictBorgMedical
+  announcement: terror-space
+  rule: DerelictMedicalCyborgSpawn
+
+- type: ninjaHackingThreat
+  id: DerelictBorgSalv
+  announcement: terror-space
+  rule: DerelictMiningCyborgSpawn
+
+- type: ninjaHackingThreat
+  id: DerelictBorgSyndi
+  announcement: terror-space
+  rule: DerelictSyndicateAssaultCyborgSpawn
+
+#- type: ninjaHackingThreat
+#  id: ParadoxClone
+#  announcement: terror-otherworldly
+#  rule: ParadoxCloneSpawn
+
+#- type: ninjaHackingThreat
+#  id: Bingle
+#  announcement: terror-otherworldly
+#  rule: BingleSpawn
+

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -7,7 +7,12 @@
     #Begin Harmony Change - expanded pool of spawns.
     LoneOp: 0.25
     Wizard: 0.25
-    DerelictBorg: 1
+    DerelictBorgEngineering: 0.16
+    DerelictBorgGeneric: 0.16
+    DerelictBorgJanitor: 0.16
+    DerelictBorgMedical: 0.16
+    DerelictBorgSalv: 0.16
+    DerelictBorgSyndi: 0.16
     ParadoxClone: 1
     Bingle: 1
     #End Harmony Change - expanded pool of spawns.
@@ -16,7 +21,7 @@
   id: Dragon
 # Start Harmony change - censors dragon spawn to keep threat secret with expanded spawn pool.
   #announcement: terror-dragon
-  announcement: terror-space 
+  announcement: terror-space
 # End Harmony change
   rule: DragonSpawn
 
@@ -24,6 +29,6 @@
   id: Revenant
 # Start Harmony change - censors rev spawn to keep threat secret with expanded pool.
   #announcement: terror-revenant
-  announcement: terror-otherworldly 
+  announcement: terror-otherworldly
 # End Harmony change
   rule: RevenantSpawn


### PR DESCRIPTION
## About the PR
This PR reworks the new ninja spawn system so that it actually works with the changes upstream made to derelict borgs.
Now derelicts have a 0.16 weighted chance to spawn, adding up to a collective 1 all together.
This means that the borg spawn slot is still the same, but we can tweak individual weights if needed (such as if the syndicate assault borg turns out to be a bit problematic or something).

## Why / Balance
If we left it the way it was it could well cause a client crash by trying to run a gamerule that doesnt exist.

## Technical details
- Splits up the gamerules from DerelictCyborgSpawn into the 6 unique chassis types in Resources/Prototypes/_Harmony/threats.yml
- Resources/Prototypes/threats.yml has been updated to include the new entries on the event table

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**


:cl:
- fix: The Ninjas comms hack system now works with the new derelict variants.

