### PR TITLE
Adds Copies of SOP Book to HOP pocket + Locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -150,6 +150,7 @@
     - id: RubberStampHop
     - id: WeaponDisabler
     - id: ClothingEyesHudCommand
+    - id: BookSOP # Harmony Change
 
 - type: entity
   id: LockerHeadOfPersonnelFilled

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -67,6 +67,7 @@
     ears: ClothingHeadsetAltCommand
     belt: BoxFolderClipboardThreePapers
     eyes: ClothingEyesHudCommand
+    pocket1: BookSOP #Harmony Change
   storage:
     back:
     - Flash


### PR DESCRIPTION
## About the PR
 I was surprised the job that interacts the most with SoP doesn't have copies of the SoP guidelines in physical form available to them. This fixes that by providing two copies - one roundstart in the HoP's pocket, and another in their locker.

## Why / Balance
I've had multiple instances recently where I've had to remind people about SoP, especially in regards to new hires recently. Hopefully having a physical copy of the book available makes it easier for people to remember SoP.
Also, it's fun to be able to throw the book at people when it comes to SoP stuff - like how sec have copies of spacelaw available to them.
They're the paperwork job! Having a book to poke at and reference is fun for RP.

## Technical details
- Adds a line and appropriate commenting to Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
- Adds a line and appropriate commenting to Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml

## Media
![image](https://github.com/user-attachments/assets/d0d9820c-4d8e-4f8a-bc34-96a7d2069ecc)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: The HoP now starts with a physical copy of the Standard Operating Procedure in their pocket.


