### PR TITLE
Adds elite suit to traitor uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1772,11 +1772,13 @@
     Telecrystal: 12
   categories:
   - UplinkWearables
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
+# Start harmony change - adds elite suit to traitor uplink
+#  conditions:
+#  - !type:StoreWhitelistCondition
+#    whitelist:
+#      tags:
+#      - NukeOpsUplink
+# End harmony change
 
 - type: listing
   id: UplinkClothingOuterHardsuitJuggernaut


### PR DESCRIPTION
## About the PR
Adds the elite suit back for traitor uplinks at 12 TC.

## Why / Balance

As per one of our Curators:
_"Originally, the Elite Hardsuit was removed under the reasoning of bloat by upstream. To which I find arguable enough to atleast want to fight back against and see if Curators will approve/disapprove._

_As of currently, heat-weak species such as Diona or Moths do not have a good way to be both space immune and have solid heat-res during active engagements and to that regard I find that the elite-hardsuit fills this niche. (If they are willing to spend the TC.) While also giving back traitors of all variety, the pricey-suit back into their uplinks if they're willing to spend their money on it._"

I agree with their take and I think that the removal of the elite suit took options away from traitors and unnecessarily restricted them. We should give more traitors more ways to fight against special ammo, especially now that it is under consideration of it being locked to only security in a current PR.

## Technical details
comments out the store conditions for elite suit offer in upstream uplink_catalog.yml, adds harmony comments

## Media
<img width="379" height="387" alt="obraz" src="https://github.com/user-attachments/assets/f489381b-d527-43f4-81e6-b1e9d9364aee" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: Added the elite suit back to traitor uplinks