### PR TITLE
Fix reptilian and vulp hardsuit helmets being errors

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -33,15 +33,17 @@
       head-vox:
       - state: equipped-head-light-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-light-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-light-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-light-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-light-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-light-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-light-dog
+      #   shader: unshaded
+      # Harmony end
   - type: Clothing
     clothingVisuals:
       head:
@@ -52,18 +54,20 @@
       - state: equipped-head-vox
       - state: equipped-head-unshaded-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-vulpkanin
-      - state: equipped-head-unshaded-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-reptilian
-      - state: equipped-head-unshaded-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-dog
-      - state: equipped-head-unshaded-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-vulpkanin
+      # - state: equipped-head-unshaded-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-reptilian
+      # - state: equipped-head-unshaded-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-dog
+      # - state: equipped-head-unshaded-dog
+      #   shader: unshaded
+      # Harmony end
   - type: PointLight
     color: "#adffe6"
   - type: PressureProtection
@@ -76,7 +80,7 @@
     reduction: 0.2
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Engineering Hardsuit
@@ -107,15 +111,17 @@
       head-vox:
       - state: equipped-head-light-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-light-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-light-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-light-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-light-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-light-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-light-dog
+      #   shader: unshaded
+      # Harmony end
   - type: Clothing
     clothingVisuals:
       head:
@@ -126,18 +132,20 @@
       - state: equipped-head-vox
       - state: equipped-head-unshaded-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-vulpkanin
-      - state: equipped-head-unshaded-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-reptilian
-      - state: equipped-head-unshaded-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-dog
-      - state: equipped-head-unshaded-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-vulpkanin
+      # - state: equipped-head-unshaded-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-reptilian
+      # - state: equipped-head-unshaded-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-dog
+      # - state: equipped-head-unshaded-dog
+      #   shader: unshaded
+      # Harmony end
   - type: PointLight
     color: "#adffe6" # Harmony: from #ffdbad
   - type: PressureProtection
@@ -145,7 +153,7 @@
     lowPressureMultiplier: 1000
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Spationaut Hardsuit
@@ -177,15 +185,17 @@
       head-vox:
       - state: equipped-head-light-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-light-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-light-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-light-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-light-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-light-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-light-dog
+      #   shader: unshaded
+      # Harmony end
   - type: Clothing
     clothingVisuals:
       head:
@@ -196,18 +206,20 @@
       - state: equipped-head-vox
       - state: equipped-head-unshaded-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-vulpkanin
-      - state: equipped-head-unshaded-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-reptilian
-      - state: equipped-head-unshaded-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-dog
-      - state: equipped-head-unshaded-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-vulpkanin
+      # - state: equipped-head-unshaded-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-reptilian
+      # - state: equipped-head-unshaded-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-dog
+      # - state: equipped-head-unshaded-dog
+      #   shader: unshaded
+      # Harmony end
   - type: PointLight
     color: "#adffe6"     #Harmony : added a color to the flashlight to match the sprite
     radius: 6
@@ -216,7 +228,7 @@
     lowPressureMultiplier: 1000
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Salvage Hardsuit
@@ -262,7 +274,7 @@
     energy: 3
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Goliath Hardsuit
@@ -295,12 +307,14 @@
       head-vox:
       - state: equipped-head-light-vox
         shader: unshaded
-      head-reptilian:
-      - state: equipped-head-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-light-dog
-        shader: unshaded
+      # Harmony start
+      # head-reptilian:
+      # - state: equipped-head-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-light-dog
+      #   shader: unshaded
+      # Harmony end
   - type: Clothing
     clothingVisuals:
       head:
@@ -311,14 +325,16 @@
       - state: equipped-head-vox
       - state: equipped-head-unshaded-vox
         shader: unshaded
-      head-reptilian:
-      - state: equipped-head-reptilian
-      - state: equipped-head-unshaded-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-dog
-      - state: equipped-head-unshaded-dog
-        shader: unshaded
+      # Harmony start
+      # head-reptilian:
+      # - state: equipped-head-reptilian
+      # - state: equipped-head-unshaded-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-dog
+      # - state: equipped-head-unshaded-dog
+      #   shader: unshaded
+      # Harmony end
   - type: PointLight
     color: "#adffe6" #Harmony : added a color to the flashlight to match the sprite
     radius: 6
@@ -327,7 +343,7 @@
     lowPressureMultiplier: 1000
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Maxim Hardsuit
@@ -402,7 +418,7 @@
         Heat: 0.9
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Brigmedic Hardsuit
@@ -526,15 +542,17 @@
       head-vox:
       - state: equipped-head-light-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-light-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-light-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-light-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-light-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-light-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-light-dog
+      #   shader: unshaded
+      # Harmony end
   - type: Clothing
     clothingVisuals:
       head:
@@ -545,18 +563,20 @@
       - state: equipped-head-vox
       - state: equipped-head-unshaded-vox
         shader: unshaded
-      head-vulpkanin:
-      - state: equipped-head-vulpkanin
-      - state: equipped-head-unshaded-vulpkanin
-        shader: unshaded
-      head-reptilian:
-      - state: equipped-head-reptilian
-      - state: equipped-head-unshaded-reptilian
-        shader: unshaded
-      head-dog:
-      - state: equipped-head-dog
-      - state: equipped-head-unshaded-dog
-        shader: unshaded
+      # Harmony start
+      # head-vulpkanin:
+      # - state: equipped-head-vulpkanin
+      # - state: equipped-head-unshaded-vulpkanin
+      #   shader: unshaded
+      # head-reptilian:
+      # - state: equipped-head-reptilian
+      # - state: equipped-head-unshaded-reptilian
+      #   shader: unshaded
+      # head-dog:
+      # - state: equipped-head-dog
+      # - state: equipped-head-unshaded-dog
+      #   shader: unshaded
+      # Harmony end
   - type: PointLight
     color: "#adffe6" # Harmony: from #daffad
   - type: PressureProtection
@@ -566,7 +586,7 @@
     reduction: 0.2
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Chief Medical Officer's Hardsuit
@@ -753,7 +773,7 @@
         Heat: 0.9
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Blood-red Medic Hardsuit
@@ -860,7 +880,7 @@
         Heat: 0.9
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Syndicate Commander Hardsuit
@@ -913,7 +933,7 @@
         Heat: 0.9
   - type: Tag
     tags:
-    - CorgiWearable
+    # - CorgiWearable # Harmony
     - WhitelistChameleon
 
 #Cybersun Juggernaut Hardsuit


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
The vulps and reptilians no longer get errors as their head.
Also disabled corgi wearing for those hardsuits because yeah.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Hardsuit helmets will no longer show up as error sprites for reptilians and vulpkanins.
- remove: More hardsuits with custom sprites are no longer wearable by smart corgis.