### PR TITLE
Space suits no longer hide lizard tails

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -145,9 +145,11 @@
       flatReductions:
         Heat: 10 # the average lightbulb only does around four damage!
     slots: OUTERCLOTHING
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 
 - type: entity
   abstract: true
@@ -177,10 +179,11 @@
       flatReductions:
         Heat: 10 # the average lightbulb only does around four damage!
     slots: OUTERCLOTHING
-  - type: HideLayerClothing
-    slots:
-    - Tail
-
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 - type: entity
   parent: ClothingOuterBase
   id: ClothingOuterBaseToggleable

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -9,9 +9,11 @@
     sprite: Clothing/OuterClothing/Bio/general.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/general.rsi
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -73,9 +73,11 @@
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
@@ -112,9 +114,11 @@
     tags:
     - CorgiWearable
     - WhitelistChameleon
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 
 - type: entity
   parent: [ClothingOuterBaseLarge, GeigerCounterClothing, AllowSuitStorageClothing]
@@ -140,9 +144,11 @@
       toggleable-clothing: !type:ContainerSlot {}
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseToggleClothing, BaseMajorContraband]
@@ -207,9 +213,11 @@
         whitelist:
           tags:
             - PowerCell
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 
 - type: entity
   parent: ClothingOuterBase
@@ -307,9 +315,11 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
-  - type: HideLayerClothing
-    slots:
-    - Tail
+# Harmony change begins - Unhides the lizard tail
+#  - type: HideLayerClothing
+#    slots:
+#    - Tail
+# Harmony change ends
 
 - type: entity
   parent: ClothingOuterSuitCarp


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Putting on a space suit will no longer hide/delete the tail of lizard players

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. It perturbs me deeply that big lizard tails disappear when putting on a space suit.
2. Maintaining lizard specific versions of suit sprites is not something I'm interested in spending effort on.

## Technical details
<!-- Summary of code changes for easier review. -->
**Upstream Files**
Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml -- Comments out hiding tails
Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml -- Comments out hiding tails
Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml -- Comments out hiding tails

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="490" height="750" alt="image" src="https://github.com/user-attachments/assets/b2334293-9021-4321-bd01-5ff9a011742b" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
