### PR TITLE
Pride Mantles are EMP-Proof

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Clothing/Neck/specific.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/Neck/specific.yml
@@ -15,7 +15,9 @@
     slot: [NECK]
     default: ClothingNeckMantleRainbow
     requireTag: WhitelistChameleonPrideMantle
+    affectedByEmp: false
   - type: UserInterface
     interfaces:
       enum.ChameleonUiKey.Key:
         type: ChameleonBoundUserInterface
+


### PR DESCRIPTION

## About the PR
This PR brings the harmony-exclusive pride mantles inline with the upstream pins, as per PR https://github.com/space-wizards/space-station-14/pull/40425.
Just adds the affectedByEmp component to the mantle and sets it to default to false.

## Why / Balance
Brings us in-line with wizden on non-traitor chameleon items.
How else will I show my alliegence to the lesbian meta-clique if i have a chance to be randomized off of it by a passing EMP? [/j].

## Technical details
- adds a line of code in Resources/Prototypes/_Harmony/Entities/Clothing/Neck/specific.yml to add the affectedByEmp component. Sets it to false.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Pride Mantles are no longer randomized by EMPs.

