### PR TITLE
Expanded QM Loadout Options

### DIFF
--- a/Resources/Locale/en-US/_Harmony/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Harmony/preferences/loadout-groups.ftl
@@ -11,3 +11,4 @@ loadout-group-librarian-neck = Librarian neck
 # Cargo
 loadout-group-salvage-specialist-neck = Salvage specialist neck
 loadout-group-salvage-specialist-id = Salvage specialist ID
+loadout-group-quartermaster-backpack = Quartermaster Backpack

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -674,6 +674,7 @@
   minLimit: 0
   loadouts:
   - QuartermasterWintercoat
+  - QuartermasterAntiqueCoat
 
 - type: loadoutGroup
   id: QuartermasterShoes
@@ -681,6 +682,7 @@
   loadouts:
   - BrownShoes
   - CargoWinterBoots
+  - SalvageBoots # Harmony Change - QM Can Wear Salvage Boots
 
 - type: loadoutGroup
   id: CargoTechnicianHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -211,7 +211,8 @@
   - QuartermasterHead
   - QuartermasterNeck
   - QuartermasterJumpsuit
-  - CargoTechnicianBackpack
+# - CargoTechnicianBackpack - Harmony Change, replaced with QM backpack group.
+  - QuartermasterBackpack
   - QuartermasterOuterClothing
   - QuartermasterShoes
   - Glasses

--- a/Resources/Prototypes/_Harmony/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Clothing/OuterClothing/coats.yml
@@ -30,4 +30,9 @@
     sprite: _Harmony/Clothing/OuterClothing/Coats/detective_disco.rsi
   - type: Clothing
     sprite: _Harmony/Clothing/OuterClothing/Coats/detective_disco.rsi
-    
+
+- type: entity
+  parent: ClothingOuterCoatPirate
+  id: ClothingOuterCoatQMAntique
+  name: quartermaster's antique overcoat
+  description: A coat thats stood the test of time. From a bygone era of selling wrenches and ripping up vending machines. A loose speso note hangs out of the pocket.

--- a/Resources/Prototypes/_Harmony/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -1,0 +1,5 @@
+# OuterClothing
+- type: loadout
+  id: QuartermasterAntiqueCoat
+  equipment:
+    outerClothing: ClothingOuterCoatQMAntique

--- a/Resources/Prototypes/_Harmony/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Harmony/Loadouts/loadout_groups.yml
@@ -43,3 +43,14 @@
   loadouts:
   - SalvagePDA
   - SeniorSalvagePDA
+
+- type: loadoutGroup
+  id: QuartermasterBackpack
+  name: loadout-group-quartermaster-backpack
+  loadouts:
+  - CargoTechnicianBackpack
+  - CargoTechnicianSatchel
+  - CargoTechnicianDuffel
+  - SalvageSpecialistBackpack
+  - SalvageSpecialistSatchel
+  - SalvageSpecialistDuffel


### PR DESCRIPTION
## About the PR
This PR aims to expand the QM's loadout options as suggested in the thread here: https://discord.com/channels/1139716325627932682/1423123756431441961

Specifically, it does the following:

- The QM can now choose from both cargo tech and salvage backpacks of all variants (backpack, satchel, and duffel)
- The QM can now choose to wear salvage boots.
- The QM has a unique overcoat parented from the pirate garb, with a unique name and description (can be resprited in future but right now its just a retooled pirates garb).

## Why / Balance
Expanded character expression, allows the QM to embody both parts of their department, and the salvage boots are too cool to be wasted on salvage where 99% of the time they're swapped roundstart for magboots.
The coat is a more personal choice, as I know a few QM's who tend to wear it, and there are several pirate inspirations in the QM's design language already (pirate revolver on barratry, hardsuit being an antique pirate suit etc).


## Technical details
- Resources/Locale/en-US/_Harmony/preferences/loadout-groups.ftl Edits file to include a new line for the added QM backpack loadout group.
- Resources/Prototypes/Loadouts/loadout_groups.yml Adds boots and coat to relevant loadout groups with appropriate commenting.
- Resources/Prototypes/Loadouts/role_loadouts.yml Comments out cargotech backpack group from the QM's loadout and replaces it with the newly added QM backpack loadout group
- Resources/Prototypes/_Harmony/Entities/Clothing/OuterClothing/coats.yml new prototype added parenting off of the pirate garb.
- Resources/Prototypes/_Harmony/Loadouts/Jobs/Cargo/quartermaster.yml new loadout specific prototype added so the coat can be loaded by the loadout groups.
- Resources/Prototypes/_Harmony/Loadouts/loadout_groups.yml New loadout group for the QM backpack slot. has both cargo and salvage options.

## Media
![image](https://github.com/user-attachments/assets/a256f685-d712-4b92-ba6d-d44bd1eb290c)
![image3](https://github.com/user-attachments/assets/b45a8616-bab5-4ba7-ae5d-7b39284713c5)
![image2](https://github.com/user-attachments/assets/1eada383-51e9-4215-bd48-4ce74f3d844c)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Adds the QM's antique overcoat, a pirate-like overcoat.
- tweak: QM's can now select salvage backpacks, and boots in the loadout selection screen.


