### PR TITLE
Update Red Phone Suffixes for Mapping Clarity

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
@@ -48,6 +48,7 @@
   parent: BaseHandheldInstrument
   id: PhoneInstrumentUpstream # Harmony
   name: red phone
+  suffix: Prayer # Harmony - The Harmony Red Phone should be mapped instead
   description: Should anything ever go wrong...
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
@@ -2,11 +2,13 @@
 # Note: the ID is hijacked from Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
 # New upstream ID: PhoneInstrumentUpstream
 # Child entites also have PhoneInstrumentUpstream parent: PhoneInstrumentSyndicate, BananaPhoneInstrument
+
+# The usual 'suffix: Harmony' has been omitted due to the sniped ID, as it simply causes confusion when mapping
+
 - type: entity
   id: PhoneInstrument
   parent: [BaseItem, BaseCommandContraband]
   name: red phone
-  suffix: harmony intercom
   description: Should anything ever go wrong...
   components:
     - type: Sprite


### PR DESCRIPTION
## About the PR
It should now be easier to tell which Red Phone prototype to map when making Maps for Harmony

## Why / Balance
PR https://github.com/ss14-harmony/ss14-harmony/pull/106 swapped the Red Phone for one that functions like an InterCom, which is both more immersive and more visible to admins.

However, that PR was made a good while before the modern Harmony standards that mandate a 'Harmony' suffix for ease of mapping, causing new mappers to be more likely to map the wrong Red Phone when creating maps for Harmony.

To fix this, the 'harmony intercom' suffix was removed from the Harmony Red Phone leaving it without a suffix, and the 'Prayer' suffix was added to the Upstream Red Phone and thus subsequently all items that parent off it.

## Technical details
Added the suffix 'Prayer' to the prototype PhoneInstrumentUpstream in Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml to dissuade mapping it.
(When I tried to add abstract: true, the tests failed. I believe at least one map is using PhoneInstrumentUpstream?)

Removed the suffix completeley from the prototype PhoneInstrument in Resources/Prototypes/_Harmony/Entities/Objects/Devices/red_phone.yml
Despite being in Harmony namespace, it is better to treat it like a modified Upstream prototype, as it has sniped the Upstream prototype ID

## Media
<img width="676" height="211" alt="image" src="https://github.com/user-attachments/assets/ede67d63-aa8d-4a09-8aeb-12d4bda3ca4a" />
The Red Phone intended to be mapped has been indicated by a blue square.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes


**Changelog**
Not a player facing change.
