### PR TITLE
Cargo Toolbelt

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -19,8 +19,9 @@
 - type: startingGear
   id: CargoTechGear
   equipment:
+    belt: ClothingBeltUtilityCargo # Harmony Change - Adds Cargo Utility Belt
     ears: ClothingHeadsetCargo
-    pocket1: AppraisalTool
+    #pocket1: AppraisalTool # Harmony Change - Moves to utility belt
   #storage:
     #back:
     #- Stuff

--- a/Resources/Prototypes/_Harmony/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/Fills/Items/belt.yml
@@ -20,3 +20,15 @@
     containers:
       storagebase: !type:NestedSelector
         tableId: BeltBrigmedHarmonyEntityTable
+
+- type: entity
+  id: ClothingBeltUtilityCargo
+  parent: ClothingBeltUtility
+  suffix: Cargo, Harmony
+  components:
+  - type: StorageFill
+    contents:
+      - id: CrowbarGreen
+      - id: Wrench
+      - id: Screwdriver
+      - id: AppraisalTool


### PR DESCRIPTION
## About the PR
This PR revives the closed upstream pr here: https://github.com/space-wizards/space-station-14/pull/40677
I feel this was closed without due merit, and would be a great addition.
I have removed the utility knife as we dont have it yet (will re-add it in future) and moved the apprasal tool from the pocket to the belt.

## Why / Balance
- All of these tools are relevant to cargo doing their job. (crowbars are used in specialized crate diassembly and are generally useful, screwdrivers are used for diassembling crates, wrenches are extremely useful for anchoring/unanchoring.
- It is thematic for the department that does a lot of manual labor, as well as being themed around dockworkers, to have utility tools and a toolbelt. However these toolbelts are not as bulked out as an engineers toolset.
- All of these tools will be printed at some point in the round by a cargo tech, this streamlines the process. Less time messing with lathes, more time actually doing bounties or mail.

## Technical details
- Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml adds the belt prototype to the loadout slot and comments out the appraisal tool.
- Adds the new prototype and fill in Resources/Prototypes/_Harmony/Catalog/Fills/Items/belt.yml.

## Media
<img width="713" height="189" alt="Untitled" src="https://github.com/user-attachments/assets/3f0fe76e-07c0-4315-8df1-3d7138591db2" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: Adds a utility belt to cargo technicians, with some basic tools to help them with their job.
- tweak: A cargo technicians appraisal tool now starts in their toolbelt, and not their pocket.

