### PR TITLE
make tritium a better fuel for a radiation collector

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -2,7 +2,7 @@
   id: RadiationCollector
   name: radiation collector
   suffix: Empty tank
-  description: A machine that collects radiation and turns it into power. Requires plasma gas to function.
+  description: A machine that collects radiation and turns it into power. Requires plasma or tritium gas to function. #harmony change
   placement:
     mode: SnapgridCenter
   components:
@@ -62,6 +62,9 @@
       - reactantPrototype: Plasma
         powerGenerationEfficiency: 1
         reactantBreakdownRate: 0.0001
+      - reactantPrototype: Tritium #harmony change start
+        powerGenerationEfficiency: 1.5
+        reactantBreakdownRate: 0.00005 #harmony change end
   - type: RadiationReceiver
   - type: PowerSupplier
   - type: Anchorable


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Now tritium will be a better fuel for a radiation collector that will last longer and create more energy!

## Why / Balance
this will add more engagment to atmoses work with regular engineers besides building TEG

## Technical details
just some changes in YML of radiation collector

## Media

<img width="375" height="264" alt="Знімок екрана 2025-10-04 093753" src="https://github.com/user-attachments/assets/9cab1d6d-a30f-4371-91a4-c1d5531c9488" />

radiation collector with a plasma

<img width="408" height="269" alt="Знімок екрана 2025-10-04 093804" src="https://github.com/user-attachments/assets/ca2f1337-af15-4687-8e20-4fdb26c090f2" />

radiation collector with a tritium

<img width="554" height="341" alt="Знімок екрана 2025-10-04 093657" src="https://github.com/user-attachments/assets/0127011c-8e7b-4a5a-b627-674de2da0ed4" />

mentioning that you can use tritium in raiation collectors in theyr description

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl: Svetoslav228
- add: now radiation collector can use tritium as better fuel! (also there is mentioning of this in it's description)
