### PR TITLE
Adds bullet tracers

### DIFF
--- a/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Systems/TracerSystem.cs
+++ b/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Systems/TracerSystem.cs
@@ -1,0 +1,93 @@
+using System.Numerics;
+using Content.Client._Emberfall.Weapons.Ranged.Overlays;
+using Content.Shared._Emberfall.Weapons.Ranged;
+using Robust.Client.Graphics;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.Client._Emberfall.Weapons.Ranged.Systems;
+
+public sealed class TracerSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _overlay.AddOverlay(new TracerOverlay(this));
+
+        SubscribeLocalEvent<TracerComponent, ComponentStartup>(OnTracerStart);
+    }
+
+    private void OnTracerStart(Entity<TracerComponent> ent, ref ComponentStartup args)
+    {
+        var xform = Transform(ent);
+        var pos = _transform.GetWorldPosition(xform);
+
+        ent.Comp.Data = new TracerData(
+            new List<Vector2> { pos },
+            _timing.CurTime + TimeSpan.FromSeconds(ent.Comp.Lifetime)
+        );
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var curTime = _timing.CurTime;
+        var query = EntityQueryEnumerator<TracerComponent, TransformComponent>();
+
+        while (query.MoveNext(out var uid, out var tracer, out var xform))
+        {
+            if (curTime > tracer.Data.EndTime)
+            {
+                RemCompDeferred<TracerComponent>(uid);
+                continue;
+            }
+
+            var currentPos = _transform.GetWorldPosition(xform);
+            tracer.Data.PositionHistory.Add(currentPos);
+
+            while (tracer.Data.PositionHistory.Count > 2 &&
+                   GetTrailLength(tracer.Data.PositionHistory) > tracer.Length)
+            {
+                tracer.Data.PositionHistory.RemoveAt(0);
+            }
+        }
+    }
+
+    private static float GetTrailLength(List<Vector2> positions)
+    {
+        var length = 0f;
+        for (var i = 1; i < positions.Count; i++)
+        {
+            length += Vector2.Distance(positions[i - 1], positions[i]);
+        }
+        return length;
+    }
+
+    public void Draw(DrawingHandleWorld handle, MapId currentMap)
+    {
+        var query = EntityQueryEnumerator<TracerComponent, TransformComponent>();
+
+        while (query.MoveNext(out _, out var tracer, out var xform))
+        {
+            if (xform.MapID != currentMap)
+                continue;
+
+            var positions = tracer.Data.PositionHistory;
+
+            if (positions.Count < 2)
+                continue;
+
+            handle.SetTransform(Matrix3x2.Identity);
+
+            for (var i = 1; i < positions.Count; i++)
+            {
+                handle.DrawLine(positions[i - 1], positions[i], tracer.Color);
+            }
+        }
+    }
+}

--- a/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Tracer/TracerOverlay.cs
+++ b/Content.Client/_Emberfall/Weapons/Ranged/Overlays/Tracer/TracerOverlay.cs
@@ -1,0 +1,23 @@
+using Content.Client._Emberfall.Weapons.Ranged.Systems;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+
+namespace Content.Client._Emberfall.Weapons.Ranged.Overlays;
+
+public sealed class TracerOverlay : Overlay
+{
+    private readonly TracerSystem _tracer;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceEntities;
+
+    public TracerOverlay(TracerSystem tracer)
+    {
+        _tracer = tracer;
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        _tracer.Draw(args.WorldHandle, args.MapId);
+    }
+}

--- a/Content.Shared/_Emberfall/Weapons/Ranged/TracerComponent.cs
+++ b/Content.Shared/_Emberfall/Weapons/Ranged/TracerComponent.cs
@@ -1,0 +1,47 @@
+using System.Numerics;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Emberfall.Weapons.Ranged;
+
+/// <summary>
+/// Added to projectiles to give them tracer effects
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class TracerComponent : Component
+{
+    /// <summary>
+    /// How long the tracer effect should remain visible for after firing
+    /// </summary>
+    [DataField]
+    public float Lifetime = 10f;
+
+    /// <summary>
+    /// The maximum length of the tracer trail
+    /// </summary>
+    [DataField]
+    public float Length = 2f;
+
+    /// <summary>
+    /// Color of the tracer line effect
+    /// </summary>
+    [DataField]
+    public Color Color = Color.Red;
+
+    [ViewVariables]
+    public TracerData Data = default!;
+}
+
+[Serializable, NetSerializable, DataRecord]
+public struct TracerData(List<Vector2> positionHistory, TimeSpan endTime)
+{
+    /// <summary>
+    /// The history of positions this tracer has moved through
+    /// </summary>
+    public List<Vector2> PositionHistory = positionHistory;
+
+    /// <summary>
+    /// When this tracer effect should end
+    /// </summary>
+    public TimeSpan EndTime = endTime;
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -14,3 +14,8 @@
     - Structural
   - type: StaminaDamageOnCollide
     damage: 60
+# Start harmony change - monolith tracers
+  - type: Tracer
+    color: "#FFFFFFFF"
+    length: 3
+# End harmony change

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -93,6 +93,11 @@
       path: /Audio/Weapons/Guns/Hits/bullet_hit.ogg
   - type: TimedDespawn
     lifetime: 10
+  # Start harmony change - monolith tracers
+  - type: Tracer
+    color: "#FFFFFFFF"
+    length: 2
+# End harmony change
 
 - type: entity
   id: BaseBulletTrigger # Trigger-on-collide bullets
@@ -131,6 +136,11 @@
     damage:
       types:
         Blunt: 1
+  # Start harmony change - monolith tracers
+  - type: Tracer
+    color: "#E98C23FF"
+    length: 2
+# End harmony change
 
 - type: entity
   id: BaseBulletIncendiary
@@ -149,6 +159,11 @@
     energy: 7.0
   - type: IgniteOnCollide
     fireStacks: 0.25
+# Start harmony change - monolith tracers
+  - type: Tracer
+    color: "#ff4300"
+    length: 2
+# End harmony change
 
 - type: entity
   id: BaseBulletAP
@@ -165,6 +180,11 @@
       types:
         Piercing: 11 # 20% decrease
     ignoreResistances: true
+# Start harmony change - monolith tracers
+  - type: Tracer
+    color: "#000000FF"
+    length: 1.5
+# End harmony change
 
 - type: entity
   id: BaseBulletUranium
@@ -180,6 +200,11 @@
     damage:
       types:
         Radiation: 11
+# Start harmony change - monolith tracers
+  - type: Tracer
+    color: "#9BE792FF"
+    length: 2
+# End harmony change
 
 # Energy projectiles
 - type: entity


### PR DESCRIPTION
## About the PR
Code is licensed under MIT

Ports bullet tracers from Monolith (https://github.com/Monolith-Station/Monolith/pull/2256) which was ported from NF which is ported from Emberfall.

Regular bullets have been given white tracers, uranium bullets have green tracers, incendiares are red, and anti materiel bullets have a longer tail.

## Why / Balance
Makes the game look good

## Technical details
Ports over TracerSystem, TracerOverlay and TracerComponent

Adds Tracer component to base, incendiary, practice, uranium and antimateriel bullet prototypes

## Media
Media taken from frontier PR

<img width="441" height="197" alt="425778821-c51d15ec-e076-481c-bc15-55cc76b9a7c9" src="https://github.com/user-attachments/assets/d35255e7-9bce-49d6-ab29-38319814d431" />
<img width="822" height="388" alt="425778750-34859fd1-147a-45a1-8bbe-7e70590fd938" src="https://github.com/user-attachments/assets/9b624ba7-978c-4664-83b6-bd662bf00d35" />
<img width="566" height="244" alt="425778804-f1bea3ac-6e4a-4f49-96b2-06c08e5c04ea" src="https://github.com/user-attachments/assets/2f101c4f-ce85-436e-891b-2bd9e1df8c68" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Ported bullet tracers from Monolith.