### PR TITLE
Revert "Clarified EORG rules"

### DIFF
--- a/Resources/ServerInfo/_Harmony/Guidebook/ServerRules/HarmonyRules/HarmonyR6.xml
+++ b/Resources/ServerInfo/_Harmony/Guidebook/ServerRules/HarmonyRules/HarmonyR6.xml
@@ -19,9 +19,9 @@
 
 	Harmony does not allow EORG.
 
-	The round is not over until everyone is returned to the lobby. You are expected to keep following rules and to stay in character. Do not start any new conflict once the round has ended.
+	The round is not over until everyone is returned to the lobby. You are expected to keep following rules and to stay in character.
 
-	Central Command and any shuttles docked to it are fully off limits considering antagonistic actions, such as theft, break-ins, etc.. This includes antagonistic actions - do not continue to pursue objectives at this time. The only exception to this rule is Zombies.
+	This includes antagonists. You may not continue pursuing your objectives during this time.
 
 	[color=#a4885c]ESCALATION RULES[/color]
 


### PR DESCRIPTION
Reverts ss14-harmony/ss14-harmony#1043

The change was requested to be reverted by the admin team