### PR TITLE
Paramedic gets external access.

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -8,13 +8,15 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobChemist
-      time: 9000 #2.5 hrs
+      time: 0 #0 hrs
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 18000 #5 hrs
+      time: 0 #0 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 36000 #10 hrs
+      time: 28800 # Harmony: 8 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 43200 # Harmony: 12 hrs
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"
@@ -28,6 +30,7 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
+  - External # Harmony: Paramedic has it, so cmo needs it.
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -8,15 +8,13 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobChemist
-      time: 0 #0 hrs
+      time: 9000 #2.5 hrs
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 0 #0 hrs
+      time: 18000 #5 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 28800 # Harmony: 8 hrs
-    - !type:OverallPlaytimeRequirement
-      time: 43200 # Harmony: 12 hrs
+      time: 36000 #10 hrs
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -28,7 +28,6 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
-  - External # Harmony: Paramedic has it, so cmo needs it.
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -13,6 +13,7 @@
   access:
   - Medical
   - Maintenance
+  - External # Harmony
   extendedAccess:
   - Chemistry
 


### PR DESCRIPTION
## About the PR
Added external access to the paramedic ID

## Why / Balance
Paramedics often need to get outside the station to recover bodies, and despite being provided with a hard suit, cannot do this on their own. Adding this gives paramedics an option outside of going to hop every shift specifically for externals, or jumping out of disposals.
## Technical details
<!-- Summary of code changes for easier review. -->
1 line is added in the .yml for paramedic
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="971" height="500" alt="Screenshot 2025-10-16 at 5 52 05 PM" src="https://github.com/user-attachments/assets/33358f53-246e-4159-babf-32cd0d15e1fc" />
CMO ID is all the grey and green, green is what the paramedic has.
* Only paramedic gets externals now, media is outdated!

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None
**Changelog**
:cl:
- tweak: Paramedic now has external access.