### PR TITLE
Make nukes rod-proof.

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -1,4 +1,8 @@
 using Content.Server.Destructible;
+// Harmony change start
+// Adds the Harmony rod bounce helper dependency so rod collisions can be reflected before normal destruction logic runs.
+using Content.Server._Harmony.ImmovableRod.Systems;
+// Harmony change end
 using Content.Server.Polymorph.Components;
 using Content.Server.Popups;
 using Content.Shared.Administration.Logs;
@@ -31,7 +35,11 @@ public sealed class ImmovableRodSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
-
+    // Harmony change start
+    // The rod bounce behavior lives in a Harmony-only helper system.
+    // Injects the Harmony bounce helper so immovable rods can bounce off protected entities.
+    [Dependency] private readonly RodIndestructibleSystem _rodIndestructible = default!;
+    // Harmony change end
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -107,6 +115,13 @@ public sealed class ImmovableRodSystem : EntitySystem
 
             return;
         }
+
+        // Harmony change start
+        // StartCollideEvent is already owned by the stock rod system.
+        // Gives the Harmony helper first chance to reflect the rod off RodIndestructible entities and stop the normal destruction path.
+        if (_rodIndestructible.TryBounceRod(uid, ref args))
+            return;
+        // Harmony change end
 
         // dont delete/hurt self if polymoprhed into a rod
         if (TryComp<PolymorphedEntityComponent>(uid, out var polymorphed))

--- a/Content.Server/_Harmony/ImmovableRod/Components/RodIndestructibleComponent.cs
+++ b/Content.Server/_Harmony/ImmovableRod/Components/RodIndestructibleComponent.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server._Harmony.ImmovableRod.Components;
+
+/// <summary>
+/// Makes an entity deflect immovable rods instead of being destroyed by them.
+/// </summary>
+[RegisterComponent]
+public sealed partial class RodIndestructibleComponent : Component
+{
+    /// <summary>
+    /// Multiplier applied to the reflected rod speed.
+    /// </summary>
+    [DataField("bounceSpeedMultiplier")]
+    public float BounceSpeedMultiplier = 1f;
+
+    /// <summary>
+    /// Prevents repeated bounce handling while the rod is still separating.
+    /// </summary>
+    [DataField("bounceCooldown", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan BounceCooldown = TimeSpan.FromSeconds(0.12f);
+
+    public EntityUid? LastRod;
+    public TimeSpan BounceBlockedUntil;
+}

--- a/Content.Server/_Harmony/ImmovableRod/Systems/RodIndestructibleSystem.cs
+++ b/Content.Server/_Harmony/ImmovableRod/Systems/RodIndestructibleSystem.cs
@@ -1,0 +1,80 @@
+using System.Numerics;
+using Content.Server._Harmony.ImmovableRod.Components;
+using Content.Server.Popups;
+using Content.Shared.Popups;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Harmony.ImmovableRod.Systems;
+
+/// <summary>
+/// Harmony-side immovable rod deflection for entities marked with <see cref="RodIndestructibleComponent"/>.
+/// </summary>
+public sealed class RodIndestructibleSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    public bool TryBounceRod(EntityUid uid, ref StartCollideEvent args)
+    {
+        if (!TryComp<RodIndestructibleComponent>(args.OtherEntity, out var rodIndestructible))
+            return false;
+
+        var now = _timing.CurTime;
+
+        if (rodIndestructible.LastRod == uid && now < rodIndestructible.BounceBlockedUntil)
+            return true;
+
+        var velocity = args.OurBody.LinearVelocity;
+        if (!TryGetReflectedVelocity(velocity, args.WorldNormal, rodIndestructible.BounceSpeedMultiplier, out var reflected))
+            return false;
+
+        rodIndestructible.LastRod = uid;
+        rodIndestructible.BounceBlockedUntil = now + rodIndestructible.BounceCooldown;
+
+        _physics.SetLinearVelocity(uid, reflected, body: args.OurBody);
+        _physics.SetAngularVelocity(uid, 0f, body: args.OurBody);
+
+        var xform = Transform(uid);
+        _transform.SetLocalRotation(uid, reflected.ToWorldAngle() + MathHelper.PiOver2, xform);
+
+        _popup.PopupCoordinates(
+            Loc.GetString("rod-indestructible-bounce-popup", ("rod", uid), ("target", args.OtherEntity)),
+            Transform(args.OtherEntity).Coordinates,
+            PopupType.LargeCaution);
+
+        return true;
+    }
+
+    private static bool TryGetReflectedVelocity(
+        Vector2 velocity,
+        Vector2 worldNormal,
+        float speedMultiplier,
+        out Vector2 reflected)
+    {
+        reflected = Vector2.Zero;
+
+        if (velocity.LengthSquared() <= 0.0001f)
+            return false;
+
+        var normal = worldNormal.LengthSquared() > 0.0001f
+            ? Vector2.Normalize(worldNormal)
+            : -Vector2.Normalize(velocity);
+
+        if (Vector2.Dot(velocity, normal) > 0f)
+            normal = -normal;
+
+        reflected = Vector2.Reflect(velocity, normal);
+
+        if (!float.IsFinite(reflected.X) || !float.IsFinite(reflected.Y) || reflected.LengthSquared() <= 0.0001f)
+            reflected = -velocity;
+
+        reflected *= speedMultiplier;
+        return true;
+    }
+}

--- a/Resources/Locale/en-US/_Harmony/immovable_rod/rod_indestructible.ftl
+++ b/Resources/Locale/en-US/_Harmony/immovable_rod/rod_indestructible.ftl
@@ -1,0 +1,1 @@
+rod-indestructible-bounce-popup = {$rod} crashes into {$target} and ricochets away!

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -117,6 +117,13 @@
       tags:
       - GhostOnlyWarp
   - type: FTLSmashImmune
+  # Harmony change start
+  # Reason for change
+  # Make the main nuclear fission explosive survive immovable rod impacts.
+  # What change does
+  # Adds the RodIndestructible component so the Harmony rod deflection system bounces rods off this entity.
+  # Harmony change end
+  - type: RodIndestructible
 
 - type: entity
   parent: NuclearBomb

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -117,13 +117,7 @@
       tags:
       - GhostOnlyWarp
   - type: FTLSmashImmune
-  # Harmony change start
-  # Reason for change
-  # Make the main nuclear fission explosive survive immovable rod impacts.
-  # What change does
-  # Adds the RodIndestructible component so the Harmony rod deflection system bounces rods off this entity.
-  # Harmony change end
-  - type: RodIndestructible
+  - type: RodIndestructible # Harmony change / Make the main nuclear fission explosive reflect immovable rod impacts.
 
 - type: entity
   parent: NuclearBomb


### PR DESCRIPTION
## About the PR
Adds a `RodIndestructible` component and hooks immovable rods into it so rods bounce off a nuke instead of instantly atomizing the atomic bomb.

Also adds a big red popup when it happens because if a rod slams into the nuke and gets sent flying since people should absolutely know that

## Why / Balance
Mainly to stop one very dumb but very real outcome that has happened SEVERAL TIMES (by me included :godo:): the nuke getting obliterated by an immovable rod.

## Technical details
- Added Harmony-only `RodIndestructible` component
- Added Harmony-only `RodIndestructible` system
- Rod bounce uses impact normal + incoming velocity to reflect the rod back out
- Added red popup flavor text for the ricochet
- Hooked `ImmovableRodSystem` into the Harmony helper with inline Harmony comments
- Added `RodIndestructible` to `NuclearBomb` in `nuke.yml`
- Yes, this works with everything 🤣

## Media
https://github.com/user-attachments/assets/9324dc0c-f165-4cd0-98aa-3b1d5a70e12f

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Nuclear Fission Explosives now reflect Immovable Rods.