### PR TITLE
Added a launch option for 2 clients

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,15 @@
                 "Client"
             ],
             "preLaunchTask": "build"
+        },
+        {
+            "name": "Server/2-Client",
+            "configurations": [
+                "Server",
+                "Client",
+                "Client"
+            ],
+            "preLaunchTask": "build"
         }
     ]
 }


### PR DESCRIPTION
## About the PR
Developers can now use the server/2-client option from visual studio code to launch two (2) clients for debugging.
This is really nice when you need to target entities that have a mind or when you're trying to test effects that require two players.

## Why / Balance
No code changes itself

## Technical details
Allows developers to launch 2 clients at the same time.

This is helpful if you have components or systems that only affect targets with the Mind component.
Or if you need to test code like the Queue System.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.

## Changelog
:cl:
- add: 2 client debug mode for vs code

