### PR TITLE
Adjusts the new traitor objectives to roll less frequently

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,9 +6,11 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 0.5 # Harmony. Change: 1 -> 0.5 #Involves helping/harming others without killing them or stealing their stuff\
-  # TraitorObjectiveGroupSabotage: 1 # Harmony Change - Reassigns the new objectives into their own group, instead of splitting them up
-  # TraitorObjectiveGroupOther: 1 # Harmony Change - Reassigns the new objectives into their own group, instead of splitting them up
-    TraitorObjectiveGroupUnique: 0.5 # Harmony Change - allocates new objectives to its own group, to lower the frequency of the new objectives.
+  # Start Harmony Change - Reassigns the new objectives into their own group, instead of splitting them up
+  # TraitorObjectiveGroupSabotage: 1
+  # TraitorObjectiveGroupOther: 1
+    TraitorObjectiveGroupUnique: 0.5
+  # End Harmony Change
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,8 +6,9 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 0.5 # Harmony. Change: 1 -> 0.5 #Involves helping/harming others without killing them or stealing their stuff\
-    TraitorObjectiveGroupSabotage: 1
-    TraitorObjectiveGroupOther: 1
+  # TraitorObjectiveGroupSabotage: 1 # Harmony Change - Reassigns the new objectives into their own group, instead of splitting them up
+  # TraitorObjectiveGroupOther: 1 # Harmony Change - Reassigns the new objectives into their own group, instead of splitting them up
+    TraitorObjectiveGroupUnique: 0.5 # Harmony Change - allocates new objectives to its own group, to lower the frequency of the new objectives.
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -400,7 +400,7 @@
   description: Nanotrasen is very interested in anomalies with potentially catastrophic consequences. Introduce them to the fire they're playing with.
   components:
   - type: Objective
-    difficulty: 2
+    difficulty: 3 # Harmony Change - adjusts difficulty of critting anoms from 2 to 3
     icon:
       sprite: Structures/Specific/anomaly.rsi
       state: anom1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -213,10 +213,14 @@
       amount: 1
     Ammonia:
       amount: 1
+    # Harmony Change - adjusts ambuzol recipe to add stellibinin
+    Stellibinin:
+      amount: 1
+    # Harmony Change End
     ZombieBlood:
-      amount: 2
+      amount: 30 # Harmony Change - increases the amount of zombie blood you need to make Ambuzol from 2 to 30
   products:
-    Ambuzol: 4
+    Ambuzol: 2 # Harmony Change - reduces the amount of yield ambuzol creates from 4 to 2
 
 - type: reaction
   id: AmbuzolPlus
@@ -224,9 +228,9 @@
     Ambuzol:
       amount: 5
     Omnizine:
-      amount: 5
+      amount: 15 # Harmony change - increases the amount of Omnizine required to make Ambuzol+ from 5 to 15
   products:
-    AmbuzolPlus: 10
+    AmbuzolPlus: 5 # Harmony Change - reduces the amount of yield Ambuzol+ creates from 10 to 5
 
 - type: reaction
   id: Synaptizine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -213,14 +213,10 @@
       amount: 1
     Ammonia:
       amount: 1
-    # Harmony Change - adjusts ambuzol recipe to add stellibinin
-    Stellibinin:
-      amount: 1
-    # Harmony Change End
     ZombieBlood:
-      amount: 30 # Harmony Change - increases the amount of zombie blood you need to make Ambuzol from 2 to 30
+      amount: 2
   products:
-    Ambuzol: 2 # Harmony Change - reduces the amount of yield ambuzol creates from 4 to 2
+    Ambuzol: 4
 
 - type: reaction
   id: AmbuzolPlus
@@ -228,9 +224,9 @@
     Ambuzol:
       amount: 5
     Omnizine:
-      amount: 15 # Harmony change - increases the amount of Omnizine required to make Ambuzol+ from 5 to 15
+      amount: 5
   products:
-    AmbuzolPlus: 5 # Harmony Change - reduces the amount of yield Ambuzol+ creates from 10 to 5
+    AmbuzolPlus: 10
 
 - type: reaction
   id: Synaptizine

--- a/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Harmony/Objectives/objectiveGroups.yml
@@ -1,4 +1,11 @@
 - type: weightedRandom
+  id: TraitorObjectiveGroupUnique
+  weights:
+    HijackTradeStationObjective: .5
+    MailFraudObjective: 1
+    SupercritAnomaliesObjective: .25
+
+- type: weightedRandom
   id: BloodBrotherObjectiveGroups
   weights:
     BloodBrotherObjectiveGroupState: 1


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Adjusted the weights of the new objectives to roll less frequently, also increased the difficulty (how the game weighs the objective) of the anom critting objective.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
After much community feedback, this change aims to lower the frequency of the new objectives rolling for traitors (Hijack ATS, Mail Fraud and Supercrit Anomalies). Due to being one of the only objectives in its group (TraitorObjectiveGroupSabotage), the anomaly objective would roll on a high frequency. This change aims to lower the frequency in which the anomaly objective rolls by increasing the difficulty and grouping it together with the mail and ATS objective. The three new objectives are grouped into TraitorObjectiveGroupUnique, and had their weights adjusted accordingly. Mail fraud was put at the highest, as it's perceived as being the most approachable of the three. The default weight of the Anom critting objective was also set to 2, and it has been adjusted up to 3 (for reference, nuke disk is a 4).

much shoutout to @dragydevi for the help on these!

## Technical details
<!-- Summary of code changes for easier review. -->
Grouped the three new objectives and adjusted the weights as such:

HijackTradeStationObjective: .5
MailFraudObjective: 1
SupercritAnomaliesObjective: .25

All the YML was edited in a way to be as modular as possible for upcoming upstream changes, since I know this is something actively being worked on by upstream.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawned in two clients multiple times on a forced map, gave them antag and observed which objectives rolled.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="2536" height="750" alt="image" src="https://github.com/user-attachments/assets/6e326eb3-58c0-440d-926e-1017deebd133" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Adjusted the weights of Hijack the ATS, Crit Anoms and Open Mail traitor objectives.