### PR TITLE
Nerf stuns - Increase the amount of hits required to stun from security equipment

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -871,7 +871,7 @@
     - proto: BulletLaserSpreadNarrow
       fireCost: 80
     - proto: BulletDisablerSmgSpread
-      fireCost: 48
+      fireCost: 40 # Harmony Change - cost lowered (48 -> 40)
       pacifismAllowedMode: true
   - type: Item
     size: Large
@@ -923,7 +923,7 @@
     - proto: BulletLaserWindowPiercingMagnum
       fireCost: 150
     - proto: BulletDisabler
-      fireCost: 62.5
+      fireCost: 66 # Harmony Change - cost increased (62.5 -> 66)
       pacifismAllowedMode: true
   - type: BatterySelfRecharger
     autoRechargeRate: 48

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -301,7 +301,7 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    damage: 30  # Harmony Change - Reverts to Pre-Buff (33 -> 30)
+    damage: 20  # Harmony Change - Lowered from Pre-Buff (33 -> 30 -> 20)
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
@@ -1170,7 +1170,7 @@
       fly-by: *flybyfixture
   - type: Ammo
   - type: StaminaDamageOnCollide
-    damage: 15
+    damage: 10 # Harmony Change - lowered (15 -> 10)
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
@@ -1245,7 +1245,7 @@
     - state: omnilaser
       shader: unshaded
   - type: StaminaDamageOnCollide
-    damage: 30
+    damage: 20 # Harmony Change - lowered (30 -> 20)
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -10,7 +10,7 @@
     - state: stunbaton_off
       map: [ "enum.ToggleableVisuals.Layer" ]
   - type: Stunbaton
-    energyPerUse: 50
+    energyPerUse: 80 # Harmony change - increased (50 -> 80)
   - type: ItemToggle
     predictable: false
     soundActivate:
@@ -41,15 +41,15 @@
     angle: 60
     animation: WeaponArcThrust
   - type: StaminaDamageOnHit
-    damage: 35
+    damage: 25 # Harmony change - lowered (35 -> 25)
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 25 # Harmony change - lowered (35 - 25)
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 960 # Harmony change - lowered (1000 -> 960)
+    startingCharge: 960 #Harmony change - lowered (1000 -> 960)
   - type: UseDelay
   - type: Item
     heldPrefix: off


### PR DESCRIPTION
## About the PR
This PR increases the amount of hits required from security equipment and adjusts "ammo" for some to make encounters with them more drawn out and allow more responses back from the one on the receiving end.

## Why / Balance
Stuns are overpowered and overstat'd, even in their pre-Wizden buff state. They are more often than not the best weapon in every single circumstance because once one is pulled out there must be an immediate reaction to them otherwise the combat encounter is already over. Once someone is stunned, they can also be kept stunned even without any restraining equipment because of how much "ammo" stun weapons have. If someone is able to get up from being stunned, they will just get stnuned again because of how slow you are and how slow stamina regen is, there is no fail state for failing to restrain someone who is stunned because you just stun them again. There are very little if any counters to stuns, with the EMP implant being the most reliable option but that even comes with an extremely small range, has limited charges, cannot be implanted again after all charges are used, makes sentencing and time spent in brig longer from the deimplanting procedure, and forces a very rigid guns blazing playstyle as security will immediately open fire once one is used regardless of the situation. Stun resistance is only for nukie equipment which means it may as well not exist given how little it comes up. Weaker antagonists such as Blood Bound, Thief, and previously Conspirators get completely shutdown by stuns as none of them have any answer to them. 

By increasing the amount of hits it takes to stun someone, this should hopefully help make encounters with them more drawn out and allow for more back and forth between fights that involve them. Increasing hits also means we may not need to add stun resistance on armors which in my opinion flies closer to microbalancing than this PR does (But stun resistance is still something I would like explored). Antagonists stealing security stun equipment also means they should not be able to freely wipe security as often with the assistance of stun weaponry and if an antagonist wants to stun someone quicker the stunprod has remained completely unchanged of it's 3 hit stun and 3 charge battery. Melee weapons should also feel much better to use as the stun baton is now 4 hits, matching the hits to crit of the energy sword meaning even if someone pulls out a baton they should still be able to crit before they are stunned.

Stun Baton: Now has 12 total charges and takes 4 hits to stun. The most overstat'd weapon in the entire game, it has no reason beating energy swords in melee and in my 3000+ hours of SS14 I can count on one hand how many times I have run out of charge. 

Disabler Bolt Weapons: Now take 5 hits to stun, lowering their effectiveness and missing a single shot means you cannot stun two people at range (with the exception of the Energy Magnum). Hopefully makes ranged combat against these feel better and escapes more viable

Mini Disabler bolt Weapons: Now take 10 hits to stun, the energy shotgun matches the stun baton in hits to stun making it still a very good riot control weapon against prisoners but not overly oppressive at range. The Disabler SMG can now only stun 3 people if every single shot hits, but honestly I could care less about the SMG and would rather see it gone in a separate PR.

idk i hate stuns i just wanna nerf them a little bit

## Technical details
Values changed and commented in Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
- WeaponEnergyShotgun BulletDisablerSmgSpread fireCost lowered from 48 to 40 Eshotgun has more ammo in stun mode
- WeaponEnergyMagnum BulletDisabler fireCost increased from 62.5 to 65 Emagnum has less ammo in stun mode

Values changed and commented in Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
- BulletDisabler StaminaDamageOnCollide damage lowered from 30 to 20 Disabler and Emagnum take 5 hits to stun
- BulletDisablerSmg StaminaDamageOnCollide damage lowered from 15 to 10 Eshotgun and Disabler SMG take 10 hits to stun
- BulletEnergyTurretDisabler StaminaDamageOnCollide damage lowered from 30 to 20 Turrets take 5 hits to stun

Values changed and commented in Resources/Prototypes/Entities/Objects/Weapons/Throwable/security.yml
- Stunbaton energyPerUse increased from 50 to 80 Batons now have 12 "ammo" with their new max charge
- Stunbaton StaminaDamageOnHit damage lowered from 35 to 25 Batons now take 4 hits to stun
- StunBaton StaminaDamageOnCollide damage lowered from 35 to 25 Throwing a baton does not do more stamina damage
- StunBaton maxCharge lowered from 1000 to 960 Batons recharge minisculely faster but have less total "ammo" with new cost
- StunBaton startingCharge lowered from 1000 to 960 Batons still spawn with full charge

## Test plan
Spawn changed equipment (Disabler, energy magnum, energy shotgun, energy SMG, turret), spawn in a humanoid test subject, shoot them with disabling weaponry

## Media

All videos shown are on the new values with test subjects fully recovered between testing

Stun Baton
https://github.com/user-attachments/assets/76cf1676-7aed-4469-b701-1f2afc7effa9

Disabler
https://github.com/user-attachments/assets/589cbc20-7abb-445b-be44-cd03c46bb68f

Energy Magnum
https://github.com/user-attachments/assets/3753dd44-6a8e-46d6-80df-8e4d1abfb023

Energy Shotgun
https://github.com/user-attachments/assets/26851e1a-1523-476d-84d5-6f49f36ca358

Disabler SMG
https://github.com/user-attachments/assets/c10b3fde-66a1-48dc-bc1e-d5b726c5b0ba

Turret
https://github.com/user-attachments/assets/93b787bb-2c65-4a13-95d3-11e4c3f05b94

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

## Changelog
:cl:
- tweak: Stun batons now require 4 hits to stun and have had their total charge lowered to 12
- tweak: Disabler bolt weaponry (Disabler, Energy magnum, stun turrets) now require 5 shots to stun
- tweak: The Energy magnum has 1 less charge in disabling mode
- tweak: Mini disabler bolt weaponry (Energy shotgun, disabler SMG) now require 10 shots to stun
- tweak: The energy shotgun now has 2 more charge in disabling mode
