### PR TITLE
Buff Hristov walking speed when wielded (not microbalance trust me)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -114,8 +114,8 @@
     capacity: 5
     proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.25
-    sprintModifier: 0.25
+    walkModifier: 0.9 # Harmony Change, increased (0.25 -> 0.9)
+    sprintModifier: 0.9 # Harmony Change, increased (0.25 -> 0.9)
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -114,8 +114,8 @@
     capacity: 5
     proto: CartridgeAntiMateriel
   - type: SpeedModifiedOnWield
-    walkModifier: 0.9 # Harmony Change, increased (0.25 -> 0.9)
-    sprintModifier: 0.9 # Harmony Change, increased (0.25 -> 0.9)
+    walkModifier: 0.6 # Harmony Change, increased (0.25 -> 0.6)
+    sprintModifier: 0.6 # Harmony Change, increased (0.25 -> 0.6)
   - type: CursorOffsetRequiresWield
   - type: EyeCursorOffset
     maxOffset: 3


### PR DESCRIPTION
## About the PR
This PR buffs the walking/sprint speed of the Hristov moderately

## Why / Balance
I believe the Hristov is rather underperforming and underutilized, as both a weapon and a tool. It's insanely slow fire rate makes it unviable as a weapon despite dealing heavy piercing and stamina damage. Even if one shot is enough to make someone back off, they could still do as much damage back with pretty much any weapon in the game. Speed is king in this game, and I do not think the Hristov's slow walking speed is justified given its other extreme downsides.

## Technical details
Values changed and commented in Resources/Prototypes/Entities/Objects/Weapons/Snipers/sniper.yml WeaponSniperHristov SpeedModifiedOnWield walkModifier and sprintModifier changed from 0.25 to 0.6

## Test plan
Spawn a hristov, wield it, wow zoomies

## Media

https://github.com/user-attachments/assets/47d9c5de-5b98-4330-b1bd-d470147c2c3b

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
none unless hyperzine juggsuits with hristovs become the go to nukie strat (i did this before and it sucked)

## Changelog
:cl:
- tweak: You now move moderately faster when wielding a Hristov

