### PR TITLE
Removes ammotechfabs from salvage's loot table

### DIFF
--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -7,8 +7,8 @@
       entries:
         - proto: AdvMopItem
           prob: 0.5
-        - proto: AmmoTechFabCircuitboard
-          cost: 2
+#       - proto: AmmoTechFabCircuitboard # Harmony Change - Removes free ammo printer in salvage loot table
+#         cost: 2
         - proto: AutolatheMachineCircuitboard
           cost: 2
         - proto: BiomassReclaimerMachineCircuitboard


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removed Ammo Tech Fab Circruit Boards from the procedurally generated salvage loot table.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Salvage does not need a zero tc way to obtain an ammo printer. The existence of this only encourages salvagers to be disconnected from the gameplay loop by rushing expeds in hopes of power gaming hard enough to get free ammo printers, completely ignoring the purpose of their job-- materials acquisition. There's already enough they get for free if they're a traitor and this one is egregiously detrimental to the overall game's health. 

## Technical details
<!-- Summary of code changes for easier review. -->
two lines of YML commented out in salvage_loot.yml

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
two lines of YML commented out in salvage_loot.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- remove: Removed ammo tech fab boards from the procedurally generated salvage loot pool!