### PR TITLE
Bugfix - lecter/estoc mags are no longer purchasable/appear in surplus crate

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -612,16 +612,18 @@
   categories:
   - UplinkAmmo
 
+# Harmony Changes - remove lecter/estoc mag from uplink
 # For the Estoc
-- type: listing
-  id: UplinkEstocAmmo
-  name: uplink-estoc-ammo-name
-  description: uplink-estoc-ammo-desc
-  productEntity: MagazineRifle
-  cost:
-    Telecrystal: 2
-  categories:
-  - UplinkAmmo
+#- type: listing
+#  id: UplinkEstocAmmo
+#  name: uplink-estoc-ammo-name
+#  description: uplink-estoc-ammo-desc
+#  productEntity: MagazineRifle
+#  cost:
+#    Telecrystal: 2
+#  categories:
+#  - UplinkAmmo
+# End Harmony Changes
 
 # for the hristov
 - type: listing


### PR DESCRIPTION
## About the PR
Title. Resolves #1426

## Why / Balance
The estoc was removed in favor of the Harmony specific traitor bandit DMR, the lecter/estoc magazine does not need to be purchasable. Removing it from the uplink also removes it from the surplus crate. This has slight balance concerns with traitors not longer being able to purchase a lecter magazine from the uplink (since the estoc shared magazines with it) but I do not care. A traitor that has stolen a lecter most likely has ways to obtain magazines for it without the uplink (raiding the armory).

## Technical details
Resources/Prototypes/Catalog/uplink_catalog.yml commented out UplinkEstocAmmo

## Test plan
Spawn uplink, look for lecter/estoc mag, wow look nothing

Spawn 50 morbillion surplus crates, open them, wow look no lecter/estoc mag

## Media

<img width="1970" height="1312" alt="image" src="https://github.com/user-attachments/assets/6a950fcf-07d1-47ac-a13f-507c8e6a0e78" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
none

## Changelog

:cl:
- fix: The estoc/lecter magazine is no longer purchasable in the uplink, nor will it appear in surplus crates
