### PR TITLE
Waffle Co. Astro Ace

### DIFF
--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -6,6 +6,9 @@ uplink-blood-red-carbine-desc = A bundle containing the stolen and improved Bloo
 uplink-rifle-bandit-name = Bandit Bundle
 uplink-rifle-bandit-desc = Contains the Bandit, a reliable semi-auto bullpup which fires devastating caseless rounds, bundled with 2 DMR magazines. Uses .30 rifle caseless ammo.
 
+uplink-rifle-foamgun-name = Donk Co. Astro Ace
+uplink-rifle-foamgun-desc = A stealthy rifle of unexpectedly good quality. Its fabricated exterior feels rugged, and its mechanisms are sturdy. Some call it a toy, others call it a tool. Everyone, however...calls it a weapon. Fires .30 rifle caliber rounds.
+
 # Explosive
 
 uplink-kudzu-grenade-name = Kudzu grenade

--- a/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Harmony/store/uplink-catalog.ftl
@@ -6,7 +6,7 @@ uplink-blood-red-carbine-desc = A bundle containing the stolen and improved Bloo
 uplink-rifle-bandit-name = Bandit Bundle
 uplink-rifle-bandit-desc = Contains the Bandit, a reliable semi-auto bullpup which fires devastating caseless rounds, bundled with 2 DMR magazines. Uses .30 rifle caseless ammo.
 
-uplink-rifle-foamgun-name = Donk Co. Astro Ace
+uplink-rifle-foamgun-name = Waffle Co. Astro Ace
 uplink-rifle-foamgun-desc = A stealthy rifle of unexpectedly good quality. Its fabricated exterior feels rugged, and its mechanisms are sturdy. Some call it a toy, others call it a tool. Everyone, however...calls it a weapon. Fires .30 rifle caliber rounds.
 
 # Explosive

--- a/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Harmony/Catalog/uplink_catalog.yml
@@ -42,6 +42,20 @@
   categories:
   - UplinkWeaponry
 
+- type: listing
+  id: UplinkRifleFoamGun
+  name: uplink-rifle-foamgun-name
+  description: uplink-rifle-foamgun-desc
+  productEntity: WeaponRifleFoamGun
+  icon: { sprite: Objects/Fun/Foam/foam_rifle.rsi, state: icon }
+  discountCategory: rareDiscounts
+  discountDownTo:
+    Telecrystal: 6
+  cost:
+    Telecrystal: 7
+  categories:
+  - UplinkWeaponry
+
 # Explosives
 
 - type: listing

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/foamGun.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/foamGun.yml
@@ -1,0 +1,31 @@
+- type: entity
+  parent: [BaseWeaponShotgun, BaseGunWieldable, BaseSyndicateContraband]
+  id: WeaponRifleFoamGun
+  name: Donk Co. Astro Ace
+  description: A stealthy rifle of unexpectedly good quality. Its fabricated exterior feels rugged, and its mechanisms are sturdy. Some call it a toy, others call it a tool. Everyone, however...calls it a weapon. Fires .30 rifle caliber rounds.
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/Foam/foam_rifle.rsi
+  - type: Clothing
+    sprite: Objects/Fun/Foam/foam_rifle.rsi
+  - type: Item
+    sprite: Objects/Fun/Foam/foam_rifle_inhand_64x.rsi
+    size: Normal
+    shape:
+    - 0,0,3,0
+  - type: Gun
+    fireRate: 1.7
+    soundGunshot:
+      collection: DMRFire
+  - type: GunRequiresWield
+  - type: BallisticAmmoProvider
+    whitelist:
+      tags:
+      - CartridgeLightRifle
+    capacity: 10
+    proto: CartridgeLightRifle
+    soundRack:
+      path: /Audio/Weapons/Guns/Cock/revolver_cock.ogg
+    soundInsert:
+      path: /Audio/Weapons/Guns/MagIn/bullet_insert.ogg
+  - type: AmmoCounter

--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/foamGun.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/foamGun.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [BaseWeaponShotgun, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponRifleFoamGun
-  name: Donk Co. Astro Ace
+  name: Waffle Co. Astro Ace
   description: A stealthy rifle of unexpectedly good quality. Its fabricated exterior feels rugged, and its mechanisms are sturdy. Some call it a toy, others call it a tool. Everyone, however...calls it a weapon. Fires .30 rifle caliber rounds.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Adds the Waffle Co. Astro Ace, a lethal version of the Foam Astro Ace toy gun.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the lack of a meta-shield on Harmony, and the culling of stealth options for antagonists, this a way to open opportunities for antagonists to be able to do evil while not being immediately valid to security. Plus. whimsy!

Here is a general break down of the weapon's stats:

Waffle Co. Astro Ace 
Cost: 7 Telecrystal
Damage: 19 damage per shot on unarmored target
The gun fires .30 rifle, with an internal magazine. This means you must reload one bullet at a time. The fire rate is set to 1.7, which is slower than the bandit, faster than the mosin. The aim of this gun is to exist as a DMR with an internal magazine, as that is not a niche filled by any gun. 

If an antagonist wants more ammo for this weapon, they will have to purchase an emag or obtain access to the secfab and reload from a .30 rifle ammo box. I decided it is not a good idea to add .30 rifle as being purchasable in the uplink because that would be a buff to the L6 Saw.

I did my best to dial in this gun to the current ecosystem of firearms without shaking up balance in a drastic way and I believe I've struck an even, balanced implementation of an internal magazine DMR. Happy to discuss any desired changed though!

Edit: Changed it to Waffle Co. for lore reasons

## Technical details
<!-- Summary of code changes for easier review. -->
Created a new yml file for the gun in the Harmony namespace, and added all the appropriate entries for the uplink entry.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Spawned in the weapon, and tested it against various guns. Made sure sprites lined up, and functioned properly.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1292" height="668" alt="image" src="https://github.com/user-attachments/assets/aec1bc8c-c737-4f9a-a730-c21c6e1b6078" />


https://github.com/user-attachments/assets/73ed84bf-2b56-4f96-a57b-65d407b5eef1

The cluwne was just for the video, characters with the clumsy trait cannot fire this gun.


## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Adds the Waffle Co. Astro Ace, a lethal version of the foam toy gun for 7 tc!