### PR TITLE
Make the Autocall for Zeds Count the Dead

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -172,7 +172,7 @@ public sealed partial class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponen
     /// <param name="includeOffStation">Include healthy players that are not on the station grid</param>
     /// <param name="includeDead">Should dead zombies be included in the count</param>
     /// <returns></returns>
-    private float GetInfectedFraction(bool includeOffStation = true, bool includeDead = false)
+    private float GetInfectedFraction(bool includeOffStation = true, bool includeDead = true) // Harmony Change: "Make the Autocall for Zeds Count the Dead" (includeDead: false -> true)
     {
         var players = GetHealthyHumans(includeOffStation);
         var zombieCount = 0;


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Made the autocall for zombie station takeover more lenient now counting the dead zombies

## Why / Balance
I bet that you've never seen the autocall ever trigger, and I believe I've only seen it once in all my time playing SS14

typically by the later points of the apocalypse theres at the very least 30-40 zombies but only 10% of them are _actually_ alive even on absolute zombie sweeps theres just not enough zombies alive to trigger the autocall, most times one of the survivors has to realize it's not been called yet, call it, then wait the 10 minutes making the round last 15-20 minutes longer than it probably has to be

## Technical details
Flipped "includeDead" from a false to a true

## Test plan
**IMPORTANT:** make sure you run "Addgamerule Zombie" or it wont work
1. Zombify 3 urists
2. Kill them since thats the entire point of the PR that it'll count dead zombies
3. Waiting... so much waiting...
4. "You feel entirely alone" spam

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have tested this pull request and written instructions on how to test it
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- tweak: Emergency shuttle call for Zombies now count the dead zombies
