### PR TITLE
Removes sentient vending machines and replaces it with bots

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -150,6 +150,11 @@
   - type: Vocalizer
   - type: DatasetVocalizer
     dataset: FirebotAd
+# Harmony Change - Allows FireBots to be sentience through the sentience event
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-mechanical
+    weight: 0.025
+# Harmony Change End
 
 - type: entity
   parent: MobSiliconBase
@@ -291,6 +296,11 @@
     interactFailureString: petting-failure-cleanbot
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
+# Harmony Change - Allows CleanBots to be sentience through the sentience event
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-mechanical
+    weight: 0.025
+# Harmony Change End
 
 - type: entity
   parent:
@@ -340,6 +350,11 @@
   - type: Inventory
     templateId: medibot
   - type: DoAfter
+  # Harmony Change - Allows Medibots to be sentience through the sentience event
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-mechanical
+    weight: 0.025
+# Harmony Change End
 
 - type: entity
   parent:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -99,9 +99,11 @@
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: Actions
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-mechanical
-    weight: 0.025 # fuck you in particular (it now needs 40 vending machines to be as likely as 1 interesting animal)
+  # Harmony Change Start - Removes vending machines from the random sentience event
+  #- type: SentienceTarget
+  #  flavorKind: station-event-random-sentience-flavor-mechanical
+  #  weight: 0.025 # fuck you in particular (it now needs 40 vending machines to be as likely as 1 interesting animal)
+  # Harmony Change End
   - type: StaticPrice
     price: 100
   - type: Appearance


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Removes sentient vending machines and gives it to Firebot, Medibot and Cleabots

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change aims to free up random sentience rolls from vending machines, which are stationary and don't really interact in a particularly dynamic way.  This role kind of just ends up being a big nothingburger, compounded by the fact that vending machines on centcomm/ATS can be selected for this. I am open to adding more things to the pool down the line, but for now, I believe that these do not consistently add to a shift in a meaningful way.

EDIT:

Per curator feedback, I have given the random sentience component to Cleanbot, Firebot and Medibots.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out four lines of YML, pasted the YML code into appropriate files for bots.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Forced a normal shift, then ran addgamerule randomsentience like 100 times, and not a single vending machine was sentient. For the bots, I spawned in the bots, ran the game rule and tested their functions after taking control.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1353" height="1295" alt="image" src="https://github.com/user-attachments/assets/2d30b1c2-0024-407e-82d2-7176bacbde6a" />
<img width="659" height="117" alt="event" src="https://github.com/user-attachments/assets/266b982b-ec3e-4d73-9209-c3e8756971e1" />
<img width="283" height="256" alt="firebot" src="https://github.com/user-attachments/assets/bb7e55cc-1bc4-46d0-952c-9098042ed11c" />
<img width="1125" height="532" alt="medibot" src="https://github.com/user-attachments/assets/95bd0bcf-aeb2-4b16-bfa5-2ac767442590" />

<img width="274" height="264" alt="cleanbot" src="https://github.com/user-attachments/assets/d976c19f-87c5-4073-8a18-acd33f8377fa" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- remove: Removes sentient vending machines.
- add: Gives random sentience to Firebots, Cleanbots and Medibots!
