### PR TITLE
L6 SAW - Require wielding, lower fire rate, increase size, increase magazine size, increase slowdown while wielding

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -47,6 +47,7 @@
     proto: CartridgeLightRifle
     capacity: 100
   - type: Item
+    size: Normal # Harmony change - increased size of L6 mag ( Small - > Normal )
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/LightRifle/light_rifle_box.rsi
   - type: MagazineVisuals

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -9,24 +9,27 @@
   - type: Item
     size: Huge
     shape:
-    - 0,0,4,3
+    - 0,0,4,4 # Harmony change - make LMGs only fit in duffel bags ( 0,0,4,3 -> 0,0,4,4 )
   - type: Clothing
     sprite: Objects/Weapons/Guns/LMGs/l6.rsi
     quickEquip: false
     slots:
     - Back
     - suitStorage
-  - type: Wieldable
-    unwieldOnUse: false
-  - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -20
+  # Begin Harmony changes - Make LMGs require wielding to shoot, remove wield bonus
+  #- type: Wieldable
+  #  unwieldOnUse: false
+  #- type: GunWieldBonus
+  #  minAngle: -20
+  #  maxAngle: -20
+  - type: GunRequiresWield
+  # End Harmony changes
   - type: Gun
     minAngle: 24
     maxAngle: 45
     angleIncrease: 4
     angleDecay: 16
-    fireRate: 8
+    fireRate: 6 # Harmony change - lowered firerate ( 8 -> 6 )
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -67,7 +70,7 @@
 - type: entity
   name: L6 SAW
   id: WeaponLightMachineGunL6
-  parent: [BaseWeaponLightMachineGun, BaseSyndicateContraband]
+  parent: [BaseWeaponLightMachineGun, BaseGunWieldable, BaseSyndicateContraband] # Harmony change - added BaseGunWieldable to L6
   description: Developed by Waffle Corp, the L6 Squad Automatic Weapon is a deadly light machine gun often used by the Gorlex Marauders. Although bulky and cumbersome, its heavy barrel and high ammo capacity make it perfect for suppressing combatants with a hail of bullets. Feeds from .30 ammo belts.
   components:
   - type: Sprite
@@ -84,16 +87,10 @@
   - type: Appearance
   - type: StaticPrice
     price: 10000
-# Start Harmony change
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
-  - type: HeldSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+# Start Harmony change - L6 slows you down a lot when wielded
   - type: SpeedModifiedOnWield
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.6
+    sprintModifier: 0.6
 # End Harmony change
 
 - type: entity


### PR DESCRIPTION
## About the PR
Title. The L6 SAW now requires wielding to be shot, has had its fire rate lowered, has been increased in size so it can only fit in duffel bags now, has had its magazine size increase so they cannot fit in pockets anymore, and now slows you down more when wielded. The syndicate assault borg variant has been unchanged

## Why / Balance
The L6 SAW simply does too much. It has an insane rate of fire and can be one handed making it a contender for the best melee weapon in the game. Being able to fire one handed also meant you could pair it with an edagger/esword/eshield and become nigh unkillable. Despite being a really big gun and receiving a nerf to move speed when worn/wielded it was barely noticeable and easily offset by things such as hyperzine.

With these changes, I hope the L6 SAW becomes less of a kill everyone for free gun but still remains a threat that must be handled appropriately.

Now requires wielding to shoot - no brainer to me, it's a big gun and equipping a shield or edagger/eshield with reflect chance feels overpowered

Lower fire rate - The fire rate is simply too high that it becomes less of a suppressing fire gun and instead the king of barrel stuffing, it has been lowered from 8 to 6 meaning it still fires faster than the Lecter but just barely. The syndicate assault borg variant has been untouched as I feel they are rather underpowered and anti-synergy with nukie teams because an EMP takes them out of the fight completely. The fire rate can easily be changed for parity if that is desired

Increased size - Can now only fit inside duffel bags which have an inherent slowdown to them, or you must use your suit storage slot to store it which means you cannot have a large air tank with you. Change from 5 x 4 to 5 x 5, matching the RD suit in size

Increased magazine size - Magazines with 100 bullets are bigger than magazines with 30 bullets, they have been changed from small to normal

Slowdown while wielding - The slowdowns for wearing and one handing the L6 SAW have been removed, they are too minuscule to notice and are unintuitive to me. The slowdown while wielding has been matched with the proposed slowdown of the buffed Hristov, a .6 modifier while wielded. Slowdown while wielded will encourage this weapon to be used as suppressing fire and not the tip of the spear

## Technical details
Values changed and commented in Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
- BaseWeaponLightMachineGun shape changed from 0,0,4,3 to 0,0,4,4 L6 SAW is now bigger
- BaseWeaponLightMachineGun type: wieldable and type: GunWieldBonus commented out with appropriate values also commented out and replaced with type: GunRequiresWield (not sure if I did this right but it works properly so)
- BaseWeaponLightMachineGun fireRate changed from 8 to 6 L6 SAW now shoots slower

- WeaponLightMachineGunL6 added parent BaseGunWieldable L6 SAW now requires wielding to be shot (again not sure if I did this right but it works)
- WeaponLightMachineGunL6 removed ClothingSpeedModifier and HeldSpeedModifier and appropriate values L6 SAW no longer slows you down from behind held or worn
- WeaponLightMachineGunL6 SpeedModifiedOnWield walkModifier and sprintModifier changed to 0.6 from 0.9 L6 SAW slows you down significantly more when wielded

## Test plan
Spawn L6 saw, wield, shoot

## Media

https://github.com/user-attachments/assets/bf04ad3d-a597-430c-8aec-e497b680891f


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
breaking the hearts of every nukie team ever

## Changelog
:cl:
- tweak: The L6 SAW now requires to be wielded to be shot
- tweak: The L6 SAW shoots slower, the syndicate assault borg variant has been unchanged
- tweak: The L6 SAW and its magazine have been increased in size
- tweak: The L6 SAW slows you down significantly when wielded but no longer slows you down when worn or held
