### PR TITLE
Arcryox Tweaks

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1349,8 +1349,8 @@
         - !type:TemperatureCondition
           max: 213.0
         damage:
-          Brute: -3
-          Burn: -3
+          Brute: -4.5 #Harmony change - -3 to -4.5
+          #Harmony change - removed Burn: -3
 
 - type: reagent
   id : Aloxadone


### PR DESCRIPTION
## About the PR
Arcryox no longer heals burn damage but heals more brute damage to be on par with aloxadone

## Why / Balance
Arcryox currently completely dominates cryo meds that work on the dead and has completely nullified the usefulness of aloxadone. By changing arcryox to only heal brute damage, I am hoping this will make aloxadone useful again to increase diversity in medicine when working with cryo pods while still allowing arcryox to be useful without completely dominating the space. The amount of brute damage that arcryox heals has likewise been increased to be on par with the burn damage that aloxadone heals to make the chemicals mirror each other, one for brutes, one for burns.

## Technical details
Changes two lines of code in medicine.yml for Arcryox, changing Brute: -3 to Brute: -4.5 and removing Burn: -3 entirely.
Comments have been added to the code indicating the changes.

## Test plan
Spawned into dev environment, set an Urist on fire and then beat the snot out of it with a chainsaw, spawned in a jug of arcryox, placed the dead Urist in the cryo pod, and applied arcryox to make sure it was only healing brute damage and was healing at the appropriate rate. 

## Media
<img width="859" height="544" alt="Arc1" src="https://github.com/user-attachments/assets/778f1b5c-565f-4c8e-873f-84ce3aa3423d" />
<img width="895" height="555" alt="Arc2" src="https://github.com/user-attachments/assets/62887c2f-0786-4b2a-ac46-bf399f45c8d5" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
:cl:
- tweak: Arcyox no longer heals burn damage, but heals increased brute damage instead.
