### PR TITLE
Auto Evac Call is now an OOC vote

### DIFF
--- a/Content.Client/Voting/UI/VoteCallMenu.xaml.cs
+++ b/Content.Client/Voting/UI/VoteCallMenu.xaml.cs
@@ -41,7 +41,10 @@ namespace Content.Client.Voting.UI
             { StandardVoteType.Restart, new CreateVoteOption("ui-vote-type-restart", new(), false, null) },
             { StandardVoteType.Preset, new CreateVoteOption("ui-vote-type-gamemode", new(), false, null) },
             { StandardVoteType.Map, new CreateVoteOption("ui-vote-type-map", new(), false, null) },
-            { StandardVoteType.Votekick, new CreateVoteOption("ui-vote-type-votekick", new(), true, 0) }
+            { StandardVoteType.Votekick, new CreateVoteOption("ui-vote-type-votekick", new(), true, 0) },
+            // Start of Harmony additions: Change Auto evac call to OOC
+            { StandardVoteType.AutoEvacCall, new CreateVoteOption("ui-vote-type-autoevac", new(), false, null) }
+            // End of Harmony additions
         };
 
         public Dictionary<string, string> VotekickReasons = new Dictionary<string, string>()

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Screens.Components;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
 using Content.Server.Station.Systems;
+using Content.Server.Voting.Managers;
 using Content.Shared.Database;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.GameTicking;
@@ -20,6 +21,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Station.Components;
+using Content.Shared.Voting;
 using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.RoundEnd
@@ -41,6 +43,9 @@ namespace Content.Server.RoundEnd
         [Dependency] private EmergencyShuttleSystem _shuttle = default!;
         [Dependency] private SharedAudioSystem _audio = default!;
         [Dependency] private StationSystem _stationSystem = default!;
+        // Start of Harmony additions: Change Auto evac call to OOC
+        [Dependency] private IVoteManager _voting = default!;
+        // End of Harmony additions
 
         public TimeSpan DefaultCooldownDuration { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -383,7 +388,10 @@ namespace Content.Server.RoundEnd
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {
-                    RequestRoundEnd(checkCooldown: false, text: "round-end-system-shuttle-auto-called-announcement");
+                    // Start of Harmony additions: Change Auto evac call to OOC
+                    // RequestRoundEnd(checkCooldown: false, text: "round-end-system-shuttle-auto-called-announcement");
+                    _voting.CreateStandardVote(null, StandardVoteType.AutoEvacCall);
+                    // End of Harmony additions
                     _autoCalledBefore = true;
                 }
 

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -38,7 +38,10 @@ namespace Content.Server.Voting.Managers
             {StandardVoteType.Restart, CCVars.VoteRestartEnabled},
             {StandardVoteType.Preset, CCVars.VotePresetEnabled},
             {StandardVoteType.Map, CCVars.VoteMapEnabled},
-            {StandardVoteType.Votekick, CCVars.VotekickEnabled}
+            {StandardVoteType.Votekick, CCVars.VotekickEnabled},
+            // Start of Harmony additions: Change Auto evac call to OOC
+            {StandardVoteType.AutoEvacCall, CCVars.AutoEvacCallEnabled}
+            // End of Harmony additions
         };
 
         public void CreateStandardVote(ICommonSession? initiator, StandardVoteType voteType, string[]? args = null)
@@ -68,6 +71,9 @@ namespace Content.Server.Voting.Managers
                 case StandardVoteType.Votekick:
                     timeoutVote = false; // Allows the timeout to be updated manually in the create method
                     CreateVotekickVote(initiator, args);
+                    break;
+                case StandardVoteType.AutoEvacCall:
+                    CreateAutoEvacVote(initiator);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(voteType), voteType, null);
@@ -590,6 +596,62 @@ namespace Content.Server.Voting.Managers
             _standardVoteTimeout[type] = _timing.RealTime + timeout;
             DirtyCanCallVoteAll();
         }
+
+        // Start of Harmony additions: Change Auto evac call to OOC
+        private void CreateAutoEvacVote(ICommonSession? initiator)
+        {
+            var alone = _playerManager.PlayerCount == 1 && initiator != null;
+            var options = new VoteOptions
+            {
+                Title = Loc.GetString("ui-vote-autoevac-title"),
+                Options =
+                {
+                    (Loc.GetString("ui-vote-autoevac-yes"), "yes"),
+                    (Loc.GetString("ui-vote-autoevac-no"), "no"),
+                },
+                Duration = alone
+                    ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteAutoEvacTimerAlone))
+                    : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteAutoEvacTimer)),
+                InitiatorTimeout = TimeSpan.FromMinutes(5)
+            };
+
+            if (alone)
+                options.InitiatorTimeout = TimeSpan.FromMinutes(1);
+
+            WirePresetVoteInitiator(options, initiator);
+
+            var vote = CreateVote(options);
+
+            vote.OnFinished += (_, _) =>
+            {
+                var votesYes = vote.VotesPerOption["yes"];
+                var votesNo = vote.VotesPerOption["no"];
+                var total = votesYes + votesNo;
+
+                var ratioRequired = _cfg.GetCVar(CCVars.VoteRestartRequiredRatio);
+                if (total > 0 && votesYes >= votesNo)
+                {
+                        _adminLogger.Add(LogType.Vote, LogImpact.Low, $"Restart vote succeeded: {votesYes}/{votesNo}");
+                        _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-autoevac-succeeded"));
+
+                        var roundEnd = _entityManager.EntitySysManager.GetEntitySystem<RoundEndSystem>();
+                        roundEnd.RequestRoundEnd(checkCooldown: false, text: "round-end-system-shuttle-auto-called-announcement");
+                }
+                else
+                {
+                    _adminLogger.Add(LogType.Vote, LogImpact.Low, $"Restart vote failed: {votesYes}/{votesNo}");
+                    _chatManager.DispatchServerAnnouncement(
+                        Loc.GetString("ui-vote-autoevac-failed"));
+                }
+            };
+
+            if (initiator != null)
+            {
+                // Cast yes vote if created the vote yourself.
+                vote.CastVote(initiator, 0);
+            }
+        }
+        // End of Harmony additions
 
         private Dictionary<string, string> GetGamePresets()
         {

--- a/Content.Shared/CCVar/CCVars.Vote.cs
+++ b/Content.Shared/CCVar/CCVars.Vote.cs
@@ -177,4 +177,26 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> VotekickIgnoreGhostReqInLobby =
         CVarDef.Create("votekick.ignore_ghost_req_in_lobby", true, CVar.SERVERONLY);
+
+    // Start of Harmony additions: Change Auto evac call to OOC
+
+    /// <summary>
+    ///     Allows enabling/disabling player-started votekick for ultimate authority
+    /// </summary>
+    public static readonly CVarDef<bool> AutoEvacCallEnabled =
+        CVarDef.Create("voteautoevaccall.enabled", false, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Sets the duration of the auto evac vote timer when alone.
+    /// </summary>
+    public static readonly CVarDef<int>
+        VoteAutoEvacTimerAlone = CVarDef.Create("voteautoevaccall.alone_timer", 30, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Sets the duration of the auto evac vote timer.
+    /// </summary>
+    public static readonly CVarDef<int>
+        VoteAutoEvacTimer = CVarDef.Create("voteautoevaccall.timer", 60, CVar.SERVERONLY);
+
+    // End of Harmony additions
 }

--- a/Content.Shared/Voting/StandardVoteType.cs
+++ b/Content.Shared/Voting/StandardVoteType.cs
@@ -23,7 +23,16 @@ public enum StandardVoteType : byte
     /// <summary>
     /// Vote to kick a player.
     /// </summary>
-    Votekick
+    Votekick,
+
+    // Start of Harmony additions: Change Auto evac call to OOC
+
+    /// <summary>
+    /// Auto magical evac call.
+    /// </summary>
+    AutoEvacCall
+
+    // End of Harmony additions
 }
 
 /// <summary>

--- a/Resources/Locale/en-US/_Harmony/voting/managers/vote-manager.ftl
+++ b/Resources/Locale/en-US/_Harmony/voting/managers/vote-manager.ftl
@@ -1,0 +1,6 @@
+﻿
+ui-vote-autoevac-title = Call the Evacuation Shuttle, letting the shift come to a close?
+ui-vote-autoevac-yes = Yes
+ui-vote-autoevac-no = No
+ui-vote-autoevac-succeeded = Evac called.
+ui-vote-autoevac-failed = Shift Extended.

--- a/Resources/Locale/en-US/_Harmony/voting/ui/vote-call-menu.ftl
+++ b/Resources/Locale/en-US/_Harmony/voting/ui/vote-call-menu.ftl
@@ -1,0 +1,2 @@
+﻿# imagine someone in command thinks it's a bug they can't call this vote
+ui-vote-type-autoevac = Evac vote


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
Makes the Auto Evac call a OOC vote

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People spamming chat with Y's and N's is honestly just LRPish and dosen't include those who are dead/don't have the means to communicate

## Technical details
<!-- Summary of code changes for easier review. -->
Added `AutoEvac` option into `StandardVoteType`
Commented out `AttemptRoundEnd` in Round end system for auto evac and replaced it with the vote
added 3 new Cvars for AutoCalling
voteautoevaccall.enabled = Sets if non admins can call this vote (Default: false)
voteautoevaccall.alone_timer = How long it should be when you're alone (Default: 30 seconds)
voteautoevaccall.timer = How long it should be when not alone (Default: 1 minute)

added 2 FTL files for the ui crap under _Harmony/resources/locale/en-US/voting/ yada yada

## Test plan
Admin exclusive
1. Go to your menu > Call Vote > then select Call Evac
2. It'll make a OOC vote menu with these options: 
<img width="406" height="107" alt="image" src="https://github.com/user-attachments/assets/487ab009-f839-496c-940b-c086c0b9d6a3" />

3. Vote Yes to Call Evac
4. Repeat but vote No to extend the shift

In-Game
change `EmergencyShuttleAutoCallTime` to 1 minute using `changecvar shuttle.auto_call_time 1` <!-- thank you rhys <3 -->
1. Wait until auto evac call
2. Vote Yes to Call Evac
3. Repeat with No and extend the shift
4. shrimple

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Non-admins can't call the vote
<img width="315" height="180" alt="image" src="https://github.com/user-attachments/assets/a363afc4-23da-4dfd-9495-761fc65400e0" />

What the vote should look like:
<img width="413" height="107" alt="image" src="https://github.com/user-attachments/assets/f6c48f9b-b88d-4a62-b7fa-83bb477a5bba" />

Both Results:
<img width="425" height="107" alt="image" src="https://github.com/user-attachments/assets/28f62653-820a-461d-8147-7d1e4c8ae046" />
<img width="129" height="25" alt="image" src="https://github.com/user-attachments/assets/baf03a75-c17a-4d59-af1f-745fb988df4c" />

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog
:cl:
- tweak: Made the auto evac call a vote OOC!


