### PR TITLE
Rotate CC's passive gate

### DIFF
--- a/Resources/Maps/_Harmony/centcomm.yml
+++ b/Resources/Maps/_Harmony/centcomm.yml
@@ -24461,7 +24461,6 @@ entities:
   - uid: 5471
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 46.5,27.5
       parent: 1
     - type: AtmosPipeColor


### PR DESCRIPTION
## About the PR
Rotates a passive gas gate on central command

## Why / Balance
The waste pipe network on CC is connected to space through a passive gate, but the passive gate is rotated such that it only allows gas to move from space into the network instead of from the network into space. Not really pressing since nobody spends enough time on CC for it to matter, but might as well fix it.

## Technical details
Removes the rotation for the passive gate (effectively a 180 degree rotation).

## Test plan
Spawn CC grid, go to atmos room, check that the arrow on the passive gate pipe points toward space.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
N/A

## Changelog
N/A
