### PR TITLE
Buffs the jailbroken energy cartridge damage

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -151,7 +151,7 @@
     impactEffect: BulletImpactShockHarmony
     damage:
       types:
-        Shock: 9
+        Shock: 20
     ignoreResistances: true
   - type: StaminaDamageOnCollide
     damage: 5


### PR DESCRIPTION
## About the PR
Massively buffs jailbroken energy cartridge damage

## Why / Balance
Currently the bloodred energy carbine is pretty much exclusively used when it comes out of a surplus crate. It has a niche, but even in that niche it's being outclassed by the other options, so I'm proposing a massive damage buff.

### Goal
the BREC as a high cost syndicate long arm should feel powerful to use, but should not outclass the ballistic options in a generic encounter. To use it effectively you'll need to prepare recharging ports and expect your target is going to be well armored, but if those stars align it should shine.

### Thoughts
The advantages of the BREC are supposed to be that it's armor piercing and it's an energy weapon. Energy weapon status comes with pros and cons, but ultimately we can consider it a positive part of its power budget since you'd pick the BREC in situations where having an energy weapon is a benefit. Its armor piercing is almost completely moot, though, since its base damage is so low.


At only 9 damage, the BREC will crit a target in ~3 seconds assuming every shot lands. That's also how long it takes a c20-r to crit a target that has a ballistic shield and a bulletproof vest.


By buffing it to 20 damage, it becomes significantly more appealing while still being a niche choice. At that damage, it still falls short of the c20-r when fighting standard-armored targets, keeping the c20 as the default option if all you seek is killing power. But if you anticipate bulletproof vests or ballistic shields, the BREC then comes out slightly ahead. And in situations where energy weapons are advantaged, such as when you have easy access to turbo rechargers, the BREC becomes a proper threat.


My first thought was to buff the damage to 15 like the other energy cartridges, but at that point it's only just on par with the c20 against bulletproof vests. I'm not convinced that that's enough for it to feel like it has a niche as an armor piercing weapon, only as an energy weapon. That may be all it needs to feel usable, but I'd like it to feel like there's common enough situations where it's the best.

### Concerns
I don't think this is enough to make the BREC the go-to long arm, but having an armor piercing weapon be powerful is worth worrying about. While reflective vests exist, they make you weak to a simple viper sidearm and are not space-worthy, so relying on them for balance is risky.

With 20 damage per shot, the BREC may start to crowd out the bandit as theyd have equivalent damage output on unarmored targets. The bandit has much better accuracy, slightly better structural damage, and is cheaper, but ultimately I suspect its usage would drop despite already being low.

### Other Considerations
- Remove the armor piercing property

Most armor doesn't have shock resistance anyway, so this wouldn't majorly impact its utility as a way to avoid armor. It would, however, open it up to interesting interactions in the future.

- Buff the damage to a lesser degree

I feel like 18-20 is the right number to have the brec feel potent, but keeping it at 15-16 to give it parity with other energy carbine cartridges would make sense too.

- Adjust the stamina damage

5 stamina damage is an unusual effect to have for an armor piercing weapon. I could see reducing the hit damage but increasing the stamina damage as an alternative approach, keeping reduced damage output but having the slowdown and eventual stun matter.

## Technical details
Increases the shock damage of BulletLaserShockHarmony in projectiles.yml from 9 to 20.

## Test plan

- Shoot an unarmored target with the brec loaded with a jailbroken energy cartridge; check the damage
- Shoot a target wearing security armor with the brec, check the damage
- Shoot a target wearing an engineering hardsuit with the brec, check the damage
- Eject then inspect the cartridge damage value to ensure it is accurate

## Media
<img width="1109" height="773" alt="image" src="https://github.com/user-attachments/assets/314e2e0e-0c8b-41dd-9440-809cffa71324" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.


## Breaking changes
N/A

## Changelog
:cl:
- tweak: Greatly increases jailbroken energy cartridge damage.
