### PR TITLE
Buff bandit firerate

### DIFF
--- a/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Harmony/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -17,7 +17,7 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-    fireRate: 2
+    fireRate: 3
     soundGunshot:
       collection: DMRFire
   - type: ChamberMagazineAmmoProvider


### PR DESCRIPTION
## About the PR
Buffs the bandit firerate from 2 to 3

## Why / Balance
Dear god this gun needs it

It has lower DPS than the C-20 with the only advantage being the perfect accuracy, which doesn't matter because I intentionally didn't give it a scope because wizden scopes give people nausea.

I might bring it back down to 2.5 if it turns out to be too powerful but right now it just needs a reason for people to use it

## Technical details
One yaml line change

## Test plan
Spawn the gun in and shoot it

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
:cl:
- tweak: Buffed the Bandit DMR's firerate from 2 to 3
