### PR TITLE
plasma cell bomb adjustments

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -202,7 +202,8 @@ public sealed partial class ExplosionSystem
         float? fireStacks,
         float? temperature,
         float currentIntensity,
-        EntityUid? cause)
+        EntityUid? cause,
+        EntityUid? ignoreCauseRes) // Harmony, optional AP for the cause of the explosion
     {
         var size = grid.Comp.TileSize;
         var gridBox = new Box2(tile * size, (tile + 1) * size);
@@ -231,7 +232,7 @@ public sealed partial class ExplosionSystem
         // process those entities
         foreach (var (uid, xform) in list)
         {
-            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause);
+            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause, ignoreCauseRes); // Harmony - ignoreCauseRes
         }
 
         // heat the atmosphere
@@ -251,7 +252,7 @@ public sealed partial class ExplosionSystem
         foreach (var entity in _anchored)
         {
             processed.Add(entity);
-            ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause);
+            ProcessEntity(entity, epicenter, damage, throwForce, id, null, fireStacks, cause, ignoreCauseRes); // Harmony - ignoreCauseRes
             tileBlocked |= IsBlockingTurf(entity);
         }
         _anchored.Clear();
@@ -275,7 +276,7 @@ public sealed partial class ExplosionSystem
         {
             // Here we only throw, no dealing damage. Containers n such might drop their entities after being destroyed, but
             // they should handle their own damage pass-through, with their own damage reduction calculation.
-            ProcessEntity(uid, epicenter, null, throwForce, id, xform, null, cause);
+            ProcessEntity(uid, epicenter, null, throwForce, id, xform, null, cause, ignoreCauseRes); // Harmony - ignoreCauseRes
         }
 
         return !tileBlocked;
@@ -312,7 +313,8 @@ public sealed partial class ExplosionSystem
         HashSet<EntityUid> processed,
         string id,
         float? fireStacks,
-        EntityUid? cause)
+        EntityUid? cause,
+        EntityUid? ignoreCauseRes) // Harmony, optional AP for the cause of the explosion
     {
         var gridBox = Box2.FromDimensions(tile * DefaultTileSize, new Vector2(DefaultTileSize, DefaultTileSize));
         var worldBox = spaceMatrix.TransformBox(gridBox);
@@ -328,7 +330,7 @@ public sealed partial class ExplosionSystem
         foreach (var (uid, xform) in state.Item1)
         {
             processed.Add(uid);
-            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause);
+            ProcessEntity(uid, epicenter, damage, throwForce, id, xform, fireStacks, cause, ignoreCauseRes); // Harmony - ignoreCauseRes
         }
 
         if (throwForce <= 0)
@@ -342,7 +344,7 @@ public sealed partial class ExplosionSystem
 
         foreach (var (uid, xform) in list)
         {
-            ProcessEntity(uid, epicenter, null, throwForce, id, xform, fireStacks, cause);
+            ProcessEntity(uid, epicenter, null, throwForce, id, xform, fireStacks, cause, ignoreCauseRes); // Harmony - ignoreCauseRes
         }
     }
 
@@ -381,8 +383,13 @@ public sealed partial class ExplosionSystem
     }
 
     private DamageSpecifier GetDamage(EntityUid uid,
-        string id, DamageSpecifier damage)
+        string id,
+        DamageSpecifier damage,
+        EntityUid? ignoreCauseRes) // Harmony, 'ignoreCauseRes' / optional AP for the cause of the explosion
     {
+        if (uid == ignoreCauseRes) // Harmony, return true damage if uid matches the ignored user
+            return damage;
+
         // TODO Explosion Performance
         // Cache this? I.e., instead of raising an event, check for a component?
         var resistanceEv = new GetExplosionResistanceEvent(id);
@@ -396,12 +403,12 @@ public sealed partial class ExplosionSystem
         return damage;
     }
 
-    private void GetEntitiesToDamage(EntityUid uid, DamageSpecifier originalDamage, string prototype)
+    private void GetEntitiesToDamage(EntityUid uid, DamageSpecifier originalDamage, string prototype, EntityUid? ignoreCauseRes) // Harmony - ignoreCauseRes
     {
         _toDamage.Clear();
 
         // don't raise BeforeExplodeEvent if the entity is completely immune to explosions
-        var thisDamage = GetDamage(uid, prototype, originalDamage);
+        var thisDamage = GetDamage(uid, prototype, originalDamage, ignoreCauseRes); // Harmony - ignoreCauseRes
         if (thisDamage.Empty)
             return;
 
@@ -424,7 +431,7 @@ public sealed partial class ExplosionSystem
             _toDamage.EnsureCapacity(_toDamage.Count + _containedEntities.Count);
             foreach (var contained in _containedEntities)
             {
-                var newDamage = GetDamage(contained, prototype, damage);
+                var newDamage = GetDamage(contained, prototype, damage, ignoreCauseRes); // Harmony - ignoreCauseRes
                 _toDamage.Add((contained, newDamage));
             }
         }
@@ -441,11 +448,12 @@ public sealed partial class ExplosionSystem
         string id,
         TransformComponent? xform,
         float? fireStacksOnIgnite,
-        EntityUid? cause)
+        EntityUid? cause,
+        EntityUid? ignoreCauseRes) // Harmony - ignoreCauseRes
     {
         if (originalDamage is not null)
         {
-            GetEntitiesToDamage(uid, originalDamage, id);
+            GetEntitiesToDamage(uid, originalDamage, id, ignoreCauseRes); // Harmony - ignoreCauseRes
             foreach (var (entity, damage) in _toDamage)
             {
                 if (!_damageableQuery.TryComp(entity, out var damageable))
@@ -712,6 +720,8 @@ sealed class Explosion
 
     public readonly EntityUid? Cause;
 
+    public readonly EntityUid? IgnoreCauseRes; // Harmony, optional AP for the cause of the explosion
+
     /// <summary>
     ///     Initialize a new instance for processing
     /// </summary>
@@ -729,12 +739,14 @@ sealed class Explosion
         IEntityManager entMan,
         EntityUid visualEnt,
         EntityUid? cause,
+        EntityUid? ignoreCauseRes, // Harmony - ignoreCauseRes
         SharedMapSystem mapSystem,
         DamageableSystem damageable,
         EntityQuery<TileHistoryComponent> historyQuery)
     {
         VisualEnt = visualEnt;
         Cause = cause;
+        IgnoreCauseRes = ignoreCauseRes; // Harmony - ignoreCauseRes
         _system = system;
         _mapSystem = mapSystem;
         ExplosionType = explosionType;
@@ -901,8 +913,8 @@ sealed class Explosion
                     ExplosionType.FireStacks,
                     ExplosionType.Temperature,
                     _currentIntensity,
-                    Cause);
-
+                    Cause,
+                    IgnoreCauseRes); // Harmony - ignoreCauseRes
                 // If the floor is not blocked by some dense object, damage the floor tiles.
                 if (canDamageFloor)
                 {
@@ -937,7 +949,8 @@ sealed class Explosion
                     ProcessedEntities,
                     ExplosionType.ID,
                     ExplosionType.FireStacks,
-                    Cause);
+                    Cause,
+                    IgnoreCauseRes); // Harmony - ignoreCauseRes
             }
 
             if (!MoveNext())
@@ -981,4 +994,5 @@ public sealed class QueuedExplosion(ExplosionPrototype proto)
     public int MaxTileBreak;
     public bool CanCreateVacuum;
     public EntityUid? Cause; // The entity that exploded, for logging purposes.
+    public EntityUid? IgnoreCauseRes; // Harmony, optional AP for the cause of the explosion
 }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -135,7 +135,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
     }
 
     /// <inheritdoc/>
-    public override void TriggerExplosive(EntityUid uid, ExplosiveComponent? explosive = null, bool delete = true, float? totalIntensity = null, float? radius = null, EntityUid? user = null)
+    public override void TriggerExplosive(EntityUid uid, ExplosiveComponent? explosive = null, bool delete = true, float? totalIntensity = null, float? radius = null, EntityUid? user = null, EntityUid? ignoreCauseRes = null) // Harmony, optional AP for the cause of the explosion
     {
         // log missing: false, because some entities (e.g. liquid tanks) attempt to trigger explosions when damaged,
         // but may not actually be explosive.
@@ -161,7 +161,8 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             explosive.TileBreakScale,
             explosive.MaxTileBreak,
             explosive.CanCreateVacuum,
-            user);
+            user,
+            ignoreCauseRes); // Harmony - ignoreCauseRes
 
         if (explosive.DeleteAfterExplosion ?? delete)
             QueueDel(uid);
@@ -229,6 +230,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         int maxTileBreak = int.MaxValue,
         bool canCreateVacuum = true,
         EntityUid? user = null,
+        EntityUid? ignoreCauseRes = null, // Harmony, optional AP for the cause of the explosion
         bool addLog = true)
     {
         var pos = Transform(uid);
@@ -237,7 +239,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
 
         var posFound = _transformSystem.TryGetMapOrGridCoordinates(uid, out var gridPos, pos);
 
-        QueueExplosion(mapPos, typeId, totalIntensity, slope, maxTileIntensity, uid, tileBreakScale, maxTileBreak, canCreateVacuum, addLog: false);
+        QueueExplosion(mapPos, typeId, totalIntensity, slope, maxTileIntensity, uid, ignoreCauseRes, tileBreakScale, maxTileBreak, canCreateVacuum, addLog: false); // Harmony - ignoreCauseRes
 
         if (!addLog)
             return;
@@ -270,6 +272,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         float slope,
         float maxTileIntensity,
         EntityUid? cause,
+        EntityUid? ignoreCauseRes = null, // Harmony, optional AP for the cause of the explosion
         float tileBreakScale = 1f,
         int maxTileBreak = int.MaxValue,
         bool canCreateVacuum = true,
@@ -313,7 +316,8 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             TileBreakScale = tileBreakScale,
             MaxTileBreak = maxTileBreak,
             CanCreateVacuum = canCreateVacuum,
-            Cause = cause
+            Cause = cause,
+            IgnoreCauseRes =  ignoreCauseRes, // Harmony, optional AP for the cause of the explosion
         };
         _explosionQueue.Enqueue(boom);
         _queuedExplosions.Add(boom);
@@ -388,6 +392,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             EntityManager,
             visualEnt,
             queued.Cause,
+            queued.IgnoreCauseRes, // Harmony, optional AP for the cause of the explosion
             _map,
             _damageableSystem,
             _tileHistoryQuery);

--- a/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/HandheldLightSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Actions;
 using Content.Server.Popups;
+using Content.Shared._Harmony.Light; // Harmony
 using Content.Shared.Actions;
 using Content.Shared.Interaction;
 using Content.Shared.Light;
@@ -214,6 +215,9 @@ namespace Content.Server.Light.EntitySystems
             _lights.SetEnabled(uid, true, pointLightComponent);
             SetActivated(uid, true, component, true);
             _activeLights.Add(uid);
+
+            var ev = new HandheldLightTurnedOnEvent(user); // Harmony, handheld lights mirror ItemToggle instead of using it so
+            RaiseLocalEvent(uid, ref ev); // Harmony
 
             return true;
         }

--- a/Content.Shared/Chemistry/Components/RiggableComponent.cs
+++ b/Content.Shared/Chemistry/Components/RiggableComponent.cs
@@ -36,4 +36,21 @@ public sealed partial class RiggableComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public ReagentQuantity Reagent = new("Plasma", FixedPoint2.New(5), null);
+
+    /// <summary>
+    /// Harmony - Last user that activated or used this entity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? LastUser;
+}
+
+
+/// <summary>
+/// Harmony - An entity with a currently rigged entity inside.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RiggedItemComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid? Child;
 }

--- a/Content.Shared/Chemistry/EntitySystems/RiggableSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RiggableSystem.cs
@@ -1,11 +1,23 @@
+using Content.Shared._Harmony.Light; // Harmony
 using Content.Shared.Administration.Logs;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Containers.ItemSlots; // Harmony
+using Content.Shared.Damage.Components; // Harmony
 using Content.Shared.Database;
 using Content.Shared.Explosion.EntitySystems;
+using Content.Shared.Interaction; // Harmony
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Kitchen;
+using Content.Shared.Medical; // Harmony
 using Content.Shared.Rejuvenate;
+using Content.Shared.Throwing; // Harmony
+using Content.Shared.Weapons.Melee; // Harmony
+using Content.Shared.Weapons.Melee.Components; // Harmony
+using Content.Shared.Weapons.Melee.Events; // Harmony
+using Content.Shared.Weapons.Ranged.Events; // Harmony
+using Robust.Shared.Containers; // Harmony
+using Robust.Shared.Timing; // Harmony
 
 namespace Content.Shared.Power.EntitySystems;
 
@@ -18,6 +30,9 @@ public sealed partial class RiggableSystem : EntitySystem
     [Dependency] private SharedBatterySystem _battery = default!;
     [Dependency] private SharedExplosionSystem _explosionSystem = default!;
     [Dependency] private SharedSolutionContainerSystem _solution = default!;
+    [Dependency] private IGameTiming _timing = default!; // Harmony
+    [Dependency] private SharedContainerSystem _container = default!; // Harmony
+    [Dependency] private SharedDefibrillatorSystem _defib = default!; // Harmony
 
     [SubscribeLocalEvent]
     private void OnRejuvenate(Entity<RiggableComponent> entity, ref RejuvenateEvent args)
@@ -27,6 +42,10 @@ public sealed partial class RiggableSystem : EntitySystem
 
         _solution.RemoveAllSolution(solution.Value);
         entity.Comp.IsRigged = false;
+
+        if (_container.TryGetContainingContainer(entity.Owner, out var container)) // Harmony
+            RemComp<RiggedItemComponent>(container.Owner); // Harmony
+
         DirtyField(entity, entity.Comp, nameof(RiggableComponent.IsRigged));
     }
 
@@ -52,15 +71,20 @@ public sealed partial class RiggableSystem : EntitySystem
         var quantity = solution.GetReagentQuantity(entity.Comp.Reagent.Reagent);
         entity.Comp.IsRigged = quantity >= entity.Comp.Reagent.Quantity;
 
+        if (!entity.Comp.IsRigged) // Harmony
+            RemComp<RiggedItemComponent>(entity.Owner);
+
         if (wasRigged || !entity.Comp.IsRigged)
             return;
 
         _adminLogger.Add(LogType.Explosion, LogImpact.Medium, $"{ToPrettyString(entity)} has been rigged up to explode when used.");
 
-        if (!TryComp<ItemToggleComponent>(entity, out var toggleComp) || !toggleComp.Activated)
-            return;
+        // Harmony / Commented out, injection itself shouldn't cause a battery to explode
 
-        Explode(entity, _battery.GetCharge(entity.Owner));
+        // if (!TryComp<ItemToggleComponent>(entity, out var toggleComp) || !toggleComp.Activated)
+            // return;
+
+        // Explode(entity, _battery.GetCharge(entity.Owner));
     }
 
     [SubscribeLocalEvent]
@@ -76,7 +100,15 @@ public sealed partial class RiggableSystem : EntitySystem
         if (args.CurrentChargeRate == 0f && args.Delta == 0f)
             return;
 
-        Explode(entity, args.CurrentCharge);
+        // Harmony Start
+
+        if (_container.TryGetContainingContainer(entity.Owner, out var container) &&
+            HasComp<DefibrillatorComponent>(container.Owner))
+            return; // Defibs to blow up when you try to use them, not when turned on
+
+        // Harmony End
+
+        Explode(entity, args.CurrentCharge, entity.Comp.LastUser); // Harmony, LastUser
     }
 
     [SubscribeLocalEvent]
@@ -85,8 +117,256 @@ public sealed partial class RiggableSystem : EntitySystem
         if (!args.Activated || !entity.Comp.IsRigged)
             return;
 
+        if (HasComp<MeleeWeaponComponent>(entity) || HasComp<DefibrillatorComponent>(entity)) // Harmony
+            return;
+
+        entity.Comp.LastUser = args.User;
+    }
+
+    // Harmony Start
+    [SubscribeLocalEvent]
+    private void OnItemToggled(Entity<RiggedItemComponent> entity, ref ItemToggledEvent args)
+    {
+        if (!args.Activated)
+            return;
+
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        riggable.LastUser = args.User;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnInserted(Entity<RiggableComponent> entity, ref EntGotInsertedIntoContainerMessage args)
+    {
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        if (!HasComp<ItemSlotsComponent>(args.Container.Owner))
+            return;
+
+        if (entity.Comp.IsRigged)
+        {
+            var item = EnsureComp<RiggedItemComponent>(args.Container.Owner);
+            item.Child = entity;
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnRemoved(Entity<RiggableComponent> entity, ref EntGotRemovedFromContainerMessage args)
+    {
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        RemComp<RiggedItemComponent>(args.Container.Owner);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnHandheldLightTurnedOn(Entity<RiggableComponent> entity, ref HandheldLightTurnedOnEvent args)
+    {
+        if (!entity.Comp.IsRigged)
+            return;
+
+        entity.Comp.LastUser = args.User;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnItemHandheldLightTurnedOn(Entity<RiggedItemComponent> entity, ref HandheldLightTurnedOnEvent args)
+    {
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        riggable.LastUser = args.User;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnAfterInteract(Entity<RiggableComponent> entity, ref AfterInteractEvent args)
+    {
+        if (!args.CanReach)
+            return;
+
+        if (args.Target is not { } target)
+            return;
+
+        if (!entity.Comp.IsRigged)
+            return;
+
+        entity.Comp.LastUser = args.User;
+
+        if (HasComp<DefibrillatorComponent>(entity))
+        {
+            if (_defib.CanZap(entity.Owner, target, args.User))
+            {
+                Explode(entity, _battery.GetCharge(entity.Owner), args.User);
+                args.Handled = true; // Just to stop the DoAfter
+            }
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnItemAfterInteract(Entity<RiggedItemComponent> entity, ref AfterInteractEvent args)
+    {
+        if (!args.CanReach)
+            return;
+
+        if (args.Target is not { } target)
+            return;
+
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        riggable.LastUser = args.User;
+
+        if (HasComp<DefibrillatorComponent>(entity))
+        {
+            if (_defib.CanZap(entity.Owner, target, args.User))
+            {
+                Explode((child, riggable), _battery.GetCharge(child), args.User);
+                args.Handled = true;
+            }
+        }
+    }
+
+    [SubscribeLocalEvent]
+    private void OnRangedInteract(Entity<RiggableComponent> entity, ref BeforeRangedInteractEvent args)
+    {
+        if (!args.CanReach)
+            return;
+
+        if (args.Target == null)
+            return;
+
+        if (!entity.Comp.IsRigged)
+            return;
+
+        entity.Comp.LastUser = args.User;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnItemRangedInteract(Entity<RiggedItemComponent> entity, ref BeforeRangedInteractEvent args)
+    {
+        if (!args.CanReach)
+            return;
+
+        if (args.Target == null)
+            return;
+
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        riggable.LastUser = args.User;
+    }
+
+    [SubscribeLocalEvent]
+    private void OnMeleeHit(Entity<RiggableComponent> entity, ref MeleeHitEvent args)
+    {
+        if (!args.IsHit)
+            return;
+
+        if (args.HitEntities.Count == 0)
+            return;
+
+        if (!entity.Comp.IsRigged)
+            return;
+
+        if (TryComp<ItemToggleComponent>(entity, out var toggle) && !toggle.Activated)
+            return;
+
         Explode(entity, _battery.GetCharge(entity.Owner), args.User);
     }
+
+    [SubscribeLocalEvent]
+    private void OnItemMeleeHit(Entity<RiggedItemComponent> entity, ref MeleeHitEvent args)
+    {
+        if (!args.IsHit)
+            return;
+
+        if (args.HitEntities.Count == 0)
+            return;
+
+        if (TryComp<ItemToggleComponent>(entity, out var toggle) && !toggle.Activated)
+            return;
+
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        Explode((child, riggable), _battery.GetCharge(child), args.User);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnThrown(Entity<RiggableComponent> entity, ref ThrownEvent args)
+    {
+        if (!HasComp<MeleeThrowOnHitComponent>(entity) && !HasComp<StaminaDamageOnCollideComponent>(entity))
+            return;
+
+        if (!entity.Comp.IsRigged)
+            return;
+
+        if (TryComp<ItemToggleComponent>(entity, out var toggle) && !toggle.Activated)
+            return;
+
+        Explode(entity, _battery.GetCharge(entity.Owner), args.User);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnItemThrown(Entity<RiggedItemComponent> entity, ref ThrownEvent args)
+    {
+        if (!HasComp<MeleeThrowOnHitComponent>(entity) && !HasComp<StaminaDamageOnCollideComponent>(entity))
+            return;
+
+        if (TryComp<ItemToggleComponent>(entity, out var toggle) && !toggle.Activated)
+            return;
+
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        Explode((child, riggable), _battery.GetCharge(child), args.User);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnShotAttempted(Entity<RiggableComponent> entity, ref ShotAttemptedEvent args)
+    {
+        if (!entity.Comp.IsRigged)
+            return;
+
+        entity.Comp.LastUser = args.User;
+
+        Explode(entity, _battery.GetCharge(entity.Owner), args.User);
+    }
+
+    [SubscribeLocalEvent]
+    private void OnItemShotAttempted(Entity<RiggedItemComponent> entity, ref ShotAttemptedEvent args)
+    {
+        if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
+            return;
+
+        if (!riggable.IsRigged)
+            return;
+
+        args.Cancel();
+
+        Explode((child, riggable), _battery.GetCharge(child), args.User);
+    }
+
+    // Harmony End
 
     public void Explode(Entity<RiggableComponent> entity, float charge, EntityUid? cause = null)
     {
@@ -96,7 +376,7 @@ public sealed partial class RiggableSystem : EntitySystem
         var radius = MathF.Min(5, MathF.Sqrt(charge) / 9);
 
         // Explosion system also queues entity deletion
-        _explosionSystem.TriggerExplosive(entity, radius: radius, user: cause);
+        _explosionSystem.TriggerExplosive(entity, radius: radius, user: cause, ignoreCauseRes: cause); // Harmony / ignoreCauseRes so that the user takes AP damage
 
         entity.Comp.Exploded = true;
         DirtyField(entity, entity.Comp, nameof(RiggableComponent.Exploded));

--- a/Content.Shared/Chemistry/EntitySystems/RiggableSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/RiggableSystem.cs
@@ -242,9 +242,6 @@ public sealed partial class RiggableSystem : EntitySystem
         if (!args.CanReach)
             return;
 
-        if (args.Target == null)
-            return;
-
         if (!entity.Comp.IsRigged)
             return;
 
@@ -255,9 +252,6 @@ public sealed partial class RiggableSystem : EntitySystem
     private void OnItemRangedInteract(Entity<RiggedItemComponent> entity, ref BeforeRangedInteractEvent args)
     {
         if (!args.CanReach)
-            return;
-
-        if (args.Target == null)
             return;
 
         if (entity.Comp.Child is not { } child || !TryComp<RiggableComponent>(child, out var riggable))
@@ -347,7 +341,7 @@ public sealed partial class RiggableSystem : EntitySystem
         if (!entity.Comp.IsRigged)
             return;
 
-        entity.Comp.LastUser = args.User;
+        args.Cancel();
 
         Explode(entity, _battery.GetCharge(entity.Owner), args.User);
     }

--- a/Content.Shared/Explosion/EntitySystems/SharedExplosionSystem.cs
+++ b/Content.Shared/Explosion/EntitySystems/SharedExplosionSystem.cs
@@ -46,7 +46,7 @@ public abstract class SharedExplosionSystem : EntitySystem
     ///     specified in the yaml / by the component, but determined dynamically (e.g., by the quantity of a
     ///     solution in a reaction).
     /// </remarks>
-    public virtual void TriggerExplosive(EntityUid uid, ExplosiveComponent? explosive = null, bool delete = true, float? totalIntensity = null, float? radius = null, EntityUid? user = null)
+    public virtual void TriggerExplosive(EntityUid uid, ExplosiveComponent? explosive = null, bool delete = true, float? totalIntensity = null, float? radius = null, EntityUid? user = null, EntityUid? ignoreCauseRes = null) // Harmony, optional AP for the cause of the explosion
     {
     }
 
@@ -66,6 +66,7 @@ public abstract class SharedExplosionSystem : EntitySystem
                                         int maxTileBreak = int.MaxValue,
                                         bool canCreateVacuum = true,
                                         EntityUid? user = null,
+                                        EntityUid? ignoreCauseRes = null, // Harmony, optional AP for the cause of the explosion
                                         bool addLog = true)
     {
     }

--- a/Content.Shared/_Harmony/Light/HandheldLightTurnedOnEvent.cs
+++ b/Content.Shared/_Harmony/Light/HandheldLightTurnedOnEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Shared._Harmony.Light;
+
+/// <summary>
+/// Raised when a handheld light is successfully turned on.
+/// </summary>
+[ByRefEvent]
+public readonly record struct HandheldLightTurnedOnEvent(EntityUid User);


### PR DESCRIPTION
<!-- If you are new to the Harmony repository, please read the [Contributing Guidelines](https://github.com/ss14-harmony/ss14-harmony/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->

RiggableSystem had a big overhaul to store who last interacted with a rigged entity, like turning it on right before it explodes. That user now takes full explosive damage from the rigged power cell, regardless of what armor they are wearing. 

Additionally, rigged stun batons now blow up when used to melee or when the user tries to throw them, provided the baton is on, rather than blowing up as soon as it is turned on. Defibrillators work similarly, detonating as soon as you start the DoAfter to revive somebody.

One thing I considered but left out was for stun batons to detonate on mob impact instead of as soon as they're thrown. it's possible, but they would effectively become mob impact grenades, and I'm not sure how to feel about that.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Being able to stack instant detonation explosives on you while wearing equipment that makes you basically immune is too strong. They're very easily accessible and can be produced in abundance with no TC cost. The whole intent of this overhaul is to make the cell bombs lethal to the user. From a design standpoint, they are either holding the bomb, or it is strapped to their body, so it isn't an outlandish change. As a result, plasma cell bombs get a buff in their intended use, since deceiving someone else into using a rigged cell now will do the full damage to them no matter what they're wearing.

## Technical details
<!-- Summary of code changes for easier review. -->
I added 'ignoreCauseRes' to the entire explosion pipeline, carrying a nullable EntityUid. If the entity taking damage matches that EntityUid, they will take full damage regardless of armor.

Like mentioned above, RiggableSystem had an overhaul. A lot of events were added so that they can either trigger the explosion directly or store who performed the interaction in a new field named LastUser. OnChargeChanged now passes LastUser into Explode as well. How it ends up turning out is that if someone uses the item, it'll save their EntityUid under LastUser, and if that interaction ends up drawing power, it'll detonate with them as ignoreCauseRes. Like turning a flashlight on which draws power and makes it go boom, or using a holofan.

I had to add a new event into HandheldLightSystem to reliably get when one is turned on, since the system mirrors ItemToggle instead of using it.

I also added a marker component (RiggedItemComponent) which is for the entity that contains a rigged cell. It has a single field that references that cell.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

Spawn in and mess around with rigged cells in flashlights, holobarriers, et cetera, while wearing explosion resistant gear. Place another mob with the same gear to compare damage. Try stun batons and defibs to see that they do not blow up as soon as they are toggled on.

NOTE: When using a chameleon projector, you take double explosion damage as it hits both the disguise and you directly. This is not related to this PR. If you use a rigged projector and take double damage, it is because it projected right as you blew up.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Not much to showcase, functions almost identically on a visual level.

## Requirements
<!-- Confirm the following by placing an X in the square brackets.
Correct: [X]
Incorrect: [ ] [X ] [ X] -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have tested this pull request and written instructions on how to test it
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

## Changelog
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed how rigged cells interact with the user.

